### PR TITLE
Deactivate IPV6 endpoint tests for now.

### DIFF
--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -111,7 +111,7 @@ function launchSingleTests
     case 16 ; test1         dump ""
     case 17 ; test1         dump_authentication ""
     case 18 ; test1         dump_encrypted "" 
-    case 19 ; test1         endpoints "" --skipEndpointsIpv6 false
+    case 19 ; test1         endpoints "" --skipEndpointsIpv6 true
     case 20 ; test1         export ""
     case 21 ; test1         foxx_manager ""
     case 22 ; test1         http_replication ""

--- a/scripts/runLimitedTests.fish
+++ b/scripts/runLimitedTests.fish
@@ -102,7 +102,7 @@ function launchSingleTests
     case  7 ; test1         catch ""
     case  8 ; test1         dump ""
     case  9 ; test1         dump_authentication ""
-    case 10 ; test1         endpoints "" --skipEndpointsIpv6 false
+    case 10 ; test1         endpoints "" --skipEndpointsIpv6 true
     case 11 ; test1         http_replication ""
     case 12 ; test1         http_server ""
     case 13 ; test1         recovery 0 --testBuckets 4/0

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -102,7 +102,7 @@ function launchSingleTests
     case  7 ; test1         catch ""
     case  8 ; test1         dump ""
     case  9 ; test1         dump_authentication ""
-    case 10 ; test1         endpoints "" --skipEndpointsIpv6 false
+    case 10 ; test1         endpoints "" --skipEndpointsIpv6 true
     case 11 ; test1         http_replication ""
     case 12 ; test1         http_server ""
     case 13 ; test1         recovery 0 --testBuckets 4/0


### PR DESCRIPTION
Reason: This does not work in Docker containers without Klimmzuege.