### PR TITLE
Fix process handling not to forget tests

### DIFF
--- a/helper.psm1
+++ b/helper.psm1
@@ -883,6 +883,7 @@ Function launchTest($which) {
     $process = $(Start-Process -FilePath "$arangosh" -ArgumentList $test['commandline'] -RedirectStandardOutput $test['StandardOutput'] -RedirectStandardError $test['StandardError'] -PassThru)
     
     $global:launcheableTests[$which]['pid'] = $process.Id
+    $global:launcheableTests[$which]['running'] = $true
     $global:launcheableTests[$which]['launchDate'] = $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH.mm.ssZ'))
 
     $str=$($test | where {($_.Name -ne "commandline")} | Out-String)
@@ -930,6 +931,7 @@ Function registerTest($testname, $index, $bucket, $filter, $moreParams, $cluster
     	$i = $global:testCount
     	$global:testCount = $global:testCount+1
     	$global:launcheableTests += @{
+    	  running=$false;
     	  weight=$testWeight;
    	  testname=$testname;
    	  identifier=$output;
@@ -1023,12 +1025,12 @@ Function LaunchController($seconds)
         $currentRunning = 0
         $currentRunningNames = @()
         ForEach ($test in $global:launcheableTests) {
-            if ($test['pid'] -gt 0) {
+            if ($test['running']) {
                 if ($test['process'].HasExited) {
                     $currentScore = $currentScore - $test['weight']
                     Write-Host "$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH.mm.ssZ')) Testrun finished: "$test['identifier'] $test['launchdate']
                     $str=$($test | where {($_.Name -ne "commandline")} | Out-String)
-                    $test['pid'] = -1
+                    $test['running'] = $false
                 }
                 Else {
                     $currentRunningNames += $test['identifier']
@@ -1041,41 +1043,45 @@ Function LaunchController($seconds)
         Write-Host "$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH.mm.ssZ')) - Waiting  - "$seconds" - Running Tests: "$a
         $seconds = $seconds - 5
     }
-    Write-Host "tests done or timeout reached. Current state of worker jobs:"
+    if ($seconds < 1) {
+      Write-Host "tests timeout reached. Current state of worker jobs:"
+    }
+    Else {
+      Write-Host "tests done. Current state of worker jobs:"
+    }
     $str=$global:launcheableTests | Out-String
     Write-Host $str
-    if ($currentRunning -gt 0) {
-        Get-WmiObject win32_process | Output-File 
-        Write-Host "$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH.mm.ssZ')) we have "$currentRunning" tests that timed out! Currently running processes:"
-        ForEach ($test in $global:launcheableTests) {
-            if ($test['pid'] -gt 0) {
-              Write-Host "Testrun timeout:"
-              $str=$($test | where {($_.Name -ne "commandline")} | Out-String)
-              Write-Host $str
-              ForEach ($childProcesses in $(Get-WmiObject win32_process | Where {$_.ParentProcessId -eq $test['pid']})) {
-                ForEach ($childChildProcesses in $(Get-WmiObject win32_process | Where {$_.ParentProcessId -eq $test['pid']})) {
-                  ForEach ($childChildChildProcesses in $(Get-WmiObject win32_process | Where {$_.ParentProcessId -eq $test['pid']})) {
-                    Write-Host "killing child3: "
-                    $str=$childChildChildProcesses | Out-String
-                    Write-Host $str
-                    Stop-Process -Force -Id $childChildChildProcesses.Handle
-                  }
-                  Write-Host "killing child2: "
-                  $str=$childChildProcesses | Out-String
-                  Write-Host $str
-                  Stop-Process -Force -Id $childChildProcesses.Handle
-                }
-                Write-Host "killing child: "
-                $str=$childProcesses | Out-String
+  
+    Get-WmiObject win32_process | Output-File 
+    Write-Host "$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH.mm.ssZ')) we have "$currentRunning" tests that timed out! Currently running processes:"
+    ForEach ($test in $global:launcheableTests) {
+        if ($test['pid'] -gt 0) {
+          Write-Host "Testrun timeout:"
+          $str=$($test | where {($_.Name -ne "commandline")} | Out-String)
+          Write-Host $str
+          ForEach ($childProcesses in $(Get-WmiObject win32_process | Where {$_.ParentProcessId -eq $test['pid']})) {
+            ForEach ($childChildProcesses in $(Get-WmiObject win32_process | Where {$_.ParentProcessId -eq $test['pid']})) {
+              ForEach ($childChildChildProcesses in $(Get-WmiObject win32_process | Where {$_.ParentProcessId -eq $test['pid']})) {
+                Write-Host "killing child3: "
+                $str=$childChildChildProcesses | Out-String
                 Write-Host $str
-
-                Stop-Process -Force -Id $childProcesses.Handle
+                Stop-Process -Force -Id $childChildChildProcesses.Handle
               }
-              Stop-Process -Force -Id $test['pid']
+              Write-Host "killing child2: "
+              $str=$childChildProcesses | Out-String
+              Write-Host $str
+              Stop-Process -Force -Id $childChildProcesses.Handle
             }
+            Write-Host "killing child: "
+            $str=$childProcesses | Out-String
+            Write-Host $str
+
+            Stop-Process -Force -Id $childProcesses.Handle
+          }
+          Stop-Process -Force -Id $test['pid']
         }
-        Get-WmiObject win32_process | Output-File 
     }
+    Get-WmiObject win32_process | Output-File 
     comm
 }
 

--- a/helper.psm1
+++ b/helper.psm1
@@ -22,6 +22,7 @@ $global:launcheableTests = @()
 $global:maxTestCount = 0
 $global:testCount = 0
 $global:portBase = 10000
+$global:result = "GOOD"
 
 $global:ok = $true
 
@@ -1043,7 +1044,7 @@ Function LaunchController($seconds)
         Write-Host "$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH.mm.ssZ')) - Waiting  - "$seconds" - Running Tests: "$a
         $seconds = $seconds - 5
     }
-    if ($seconds < 1) {
+    if ($seconds -lt 1) {
       Write-Host "tests timeout reached. Current state of worker jobs:"
     }
     Else {
@@ -1066,20 +1067,18 @@ Function LaunchController($seconds)
                 $str=$childChildChildProcesses | Out-String
                 Write-Host $str
                 Stop-Process -Force -Id $childChildChildProcesses.Handle
-                Set-Variable -Name "ok" -Value $false -Scope global
               }
               Write-Host "killing child2: "
               $str=$childChildProcesses | Out-String
               Write-Host $str
               Stop-Process -Force -Id $childChildProcesses.Handle
-              Set-Variable -Name "ok" -Value $false -Scope global
             }
             Write-Host "killing child: "
             $str=$childProcesses | Out-String
             Write-Host $str
-            Set-Variable -Name "ok" -Value $false -Scope global
 
             Stop-Process -Force -Id $childProcesses.Handle
+            $global:result = "BAD"
           }
           Stop-Process -Force -Id $test['pid']
         }
@@ -1111,7 +1110,6 @@ Function createReport
 {
     $date = $(Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH.mm.ssZ")
     $date | Add-Content "$env:TMP\testProtocol.txt"
-    $global:result = "GOOD"
     $global:badtests = $null
     new-item $env:TMP\oskar-junit-report -itemtype directory
     ForEach($dir in (Get-ChildItem -Path $env:TMP  -Directory -Filter "*.out"))

--- a/helper.psm1
+++ b/helper.psm1
@@ -1053,7 +1053,7 @@ Function LaunchController($seconds)
     $str=$global:launcheableTests | Out-String
     Write-Host $str
   
-    Get-WmiObject win32_process | Output-File 
+    Get-WmiObject win32_process | Out-File 
     Write-Host "$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH.mm.ssZ')) we have "$currentRunning" tests that timed out! Currently running processes:"
     ForEach ($test in $global:launcheableTests) {
         if ($test['pid'] -gt 0) {
@@ -1083,7 +1083,7 @@ Function LaunchController($seconds)
           Stop-Process -Force -Id $test['pid']
         }
     }
-    Get-WmiObject win32_process | Output-File 
+    Get-WmiObject win32_process | Out-File 
     comm
 }
 

--- a/helper.psm1
+++ b/helper.psm1
@@ -1024,7 +1024,7 @@ Function LaunchController($seconds)
         $currentRunningNames = @()
         ForEach ($test in $global:launcheableTests) {
             if ($test['pid'] -gt 0) {
-                if ($test['process'].HasExited()) {
+                if ($test['process'].HasExited) {
                     $currentScore = $currentScore - $test['weight']
                     Write-Host "$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH.mm.ssZ')) Testrun finished: "$test['identifier'] $test['launchdate']
                     $str=$($test | where {($_.Name -ne "commandline")} | Out-String)

--- a/helper.psm1
+++ b/helper.psm1
@@ -887,6 +887,7 @@ Function launchTest($which) {
 
     $str=$($test | where {($_.Name -ne "commandline")} | Out-String)
     Write-Host $str
+    $global:launcheableTests[$which]['process'] = $process
     Pop-Location
 }
 
@@ -1023,15 +1024,15 @@ Function LaunchController($seconds)
         $currentRunningNames = @()
         ForEach ($test in $global:launcheableTests) {
             if ($test['pid'] -gt 0) {
-                if ($(Get-WmiObject win32_process | Where {$_.ProcessId -eq $test['pid']})) {
-                  $currentRunningNames += $test['identifier']
-                  $currentRunning = $currentRunning+1
-                }
-                Else {
+                if ($test['process'].HasExited()) {
                     $currentScore = $currentScore - $test['weight']
                     Write-Host "$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH.mm.ssZ')) Testrun finished: "$test['identifier'] $test['launchdate']
                     $str=$($test | where {($_.Name -ne "commandline")} | Out-String)
                     $test['pid'] = -1
+                }
+                Else {
+                    $currentRunningNames += $test['identifier']
+                    $currentRunning = $currentRunning+1
                 }
             }
         }

--- a/helper.psm1
+++ b/helper.psm1
@@ -1053,7 +1053,7 @@ Function LaunchController($seconds)
     $str=$global:launcheableTests | Out-String
     Write-Host $str
   
-    Get-WmiObject win32_process | Out-File 
+    Get-WmiObject win32_process | Out-File -filepath $env:TMP\processes-before.txt
     Write-Host "$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH.mm.ssZ')) we have "$currentRunning" tests that timed out! Currently running processes:"
     ForEach ($test in $global:launcheableTests) {
         if ($test['pid'] -gt 0) {
@@ -1083,7 +1083,7 @@ Function LaunchController($seconds)
           Stop-Process -Force -Id $test['pid']
         }
     }
-    Get-WmiObject win32_process | Out-File 
+    Get-WmiObject win32_process | Out-File -filepath $env:TMP\processes-after.txt 
     comm
 }
 

--- a/helper.psm1
+++ b/helper.psm1
@@ -1066,15 +1066,18 @@ Function LaunchController($seconds)
                 $str=$childChildChildProcesses | Out-String
                 Write-Host $str
                 Stop-Process -Force -Id $childChildChildProcesses.Handle
+                Set-Variable -Name "ok" -Value $false -Scope global
               }
               Write-Host "killing child2: "
               $str=$childChildProcesses | Out-String
               Write-Host $str
               Stop-Process -Force -Id $childChildProcesses.Handle
+              Set-Variable -Name "ok" -Value $false -Scope global
             }
             Write-Host "killing child: "
             $str=$childProcesses | Out-String
             Write-Host $str
+            Set-Variable -Name "ok" -Value $false -Scope global
 
             Stop-Process -Force -Id $childProcesses.Handle
           }


### PR DESCRIPTION
as recommended by @mpoeter directly work with the process object instead of using WMI and matching it.