### PR TITLE
first copy 3.3 style catch tests to the regular bin/buildmode directory

### DIFF
--- a/helper.psm1
+++ b/helper.psm1
@@ -699,11 +699,11 @@ Function buildWindows
     proc -process "cmake" -argument "--build . --config `"$BUILDMODE`"" -logfile "$INNERWORKDIR\build"
     If($global:ok)
     {
-        Copy-Item "$global:ARANGODIR\build\bin\$BUILDMODE\*" -Destination "$global:ARANGODIR\build\bin\"; comm
         If(Test-Path -PathType Container -Path "$global:ARANGODIR\build\tests\$BUILDMODE")
         {
-          Copy-Item "$global:ARANGODIR\build\tests\$BUILDMODE\*" -Destination "$global:ARANGODIR\build\tests\"; comm
+          Copy-Item "$global:ARANGODIR\build\tests\$BUILDMODE\*" -Destination "$global:ARANGODIR\build\bin\$BUILDMODE\"; comm
         }
+        Copy-Item "$global:ARANGODIR\build\bin\$BUILDMODE\*" -Destination "$global:ARANGODIR\build\bin\"; comm
     }
     Pop-Location
 }


### PR DESCRIPTION
 so later crashreport zips contain all data