### PR TITLE
Docs: If there are no Example/*.json files, we need to skip the loop entirely

### DIFF
--- a/containers/documentation.docker/buildLib
+++ b/containers/documentation.docker/buildLib
@@ -592,6 +592,11 @@ cross_source_check_docublocks() { #TODO review
 
     # These files are converted to docublocks on the fly and only live in memory.
     local example_dir="$ARANGO_SOURCE_DOC/Examples/"
+
+    # expand filename patterns to null string if no files match instead of to return themselves
+    # https://www.endpoint.com/blog/2016/12/12/bash-loop-wildcards-nullglob-failglob
+    shopt -s nullglob
+
     for file in "$example_dir"*.json ; do
         local file_name="${file#$example_dir}"
         local app=${file_name%.json}
@@ -599,6 +604,9 @@ cross_source_check_docublocks() { #TODO review
                            -e "s;.json;;" \
         >> /tmp/rawinprog.txt
     done
+
+    # disable optional behavior again
+    shopt -u nullglob
 
     echo "Generated: startDocuBlockInline errorCodes">> /tmp/rawinprog.txt
     debug "lines rawinprog $(cat /tmp/rawinprog.txt | wc -l)"


### PR DESCRIPTION
If there are no JSON files, then `for file in "$example_dir"*.json ; do` will lead to the loop being executed once, with the filename pattern itself (literally `.../Examples/*.json`), which leads to an entry `program_options*` in `inprog.txt` ultimately leading to a docu build check failing.

_nullglob_ is an optional bash behavior to expand to a null string under such circumstances, effectively skipping the entire for loop construct as it was intended.

Fixes building in <3.4:
```
Error: Not all blocks were found on both sides:
Documentation      |     Programcode:
	program_options_*
Program code:
Generated: @startDocuBlock program_options_*
There is a mismatch of DocuBlocks used in the Documenation the Blocks provided
```