### PR TITLE
make arangodb docker logging similar to to the official docker

### DIFF
--- a/containers/arangodb.docker/setup.sh
+++ b/containers/arangodb.docker/setup.sh
@@ -11,6 +11,7 @@ mkdir /docker-entrypoint-initdb.d/
 
 # Bind to all endpoints (in the container):
 sed -i -e 's~^endpoint.*8529$~endpoint = tcp://0.0.0.0:8529~' /etc/arangodb3/arangod.conf
+sed -i -e 's~^file =.*~file = -~' /etc/arangodb3/arangod.conf
 # Remove the uid setting in the config file, since we want to be able
 # to run as an arbitrary user:
 sed -i -e 's~^uid = .*$~~' /etc/arangodb3/arangod.conf


### PR DESCRIPTION
The `arangodb/arangodb` docker container behaves different to the `_/arangodb` container in terms of logging. 
This was discovered by @rocketraman in https://github.com/arangodb/arangodb/issues/7914 and will be fixing https://github.com/arangodb/arangodb-docker/issues/62

