### PR TITLE
Snippets 3.4 - Fix whitespace in debian.html.in

### DIFF
--- a/snippets/3.4/debian.html.in
+++ b/snippets/3.4/debian.html.in
@@ -55,23 +55,17 @@
   <p>
     First add the repository key to apt like this:
   </p>
-  <pre>
-    curl -OL https://download.arangodb.com@DOWNLOAD_LINK@/@ARANGODB_REPO@/DEBIAN/Release.key
-    sudo apt-key add - < Release.key
-  </pre>
+  <pre>curl -OL https://download.arangodb.com@DOWNLOAD_LINK@/@ARANGODB_REPO@/DEBIAN/Release.key
+sudo apt-key add - < Release.key</pre>
   <p>
     Use apt-get to install arangodb:
   </p>
-  <pre>
-    echo 'deb https://download.arangodb.com@DOWNLOAD_LINK@/@ARANGODB_REPO@/DEBIAN/ /' | sudo tee /etc/apt/sources.list.d/arangodb.list
-    sudo apt-get install apt-transport-https
-    sudo apt-get update
-    sudo apt-get install @ARANGODB_PKG_NAME@=@DEBIAN_VERSION@
-  </pre>
+  <pre>echo 'deb https://download.arangodb.com@DOWNLOAD_LINK@/@ARANGODB_REPO@/DEBIAN/ /' | sudo tee /etc/apt/sources.list.d/arangodb.list
+sudo apt-get install apt-transport-https
+sudo apt-get update
+sudo apt-get install @ARANGODB_PKG_NAME@=@DEBIAN_VERSION@</pre>
   <p>
     To install the debug symbols package (not required by default)
   </p>
-  <pre>
-    sudo apt-get install @ARANGODB_PKG_NAME@-dbg=@DEBIAN_VERSION@
-  </pre>
+  <pre>sudo apt-get install @ARANGODB_PKG_NAME@-dbg=@DEBIAN_VERSION@</pre>
 </div>

--- a/snippets/3.4/suse.html.in
+++ b/snippets/3.4/suse.html.in
@@ -1,6 +1,6 @@
 <div>
   <p>
-    The following packages are for OpenSUSE and SuSE Enterprise Linux (SLE).
+    The following packages are for openSUSE and SUSE Enterprise Linux (SLE).
   </p>
   <p>
     The processor(s) must support the SSE 4.2 instruction set


### PR DESCRIPTION
Indention and line breaks inside `<pre>` element in source end up in the output. This fixes the unwanted whitespace.