### PR TITLE
Skip Drivers book in <= 3.3 / Compare book.json plugins only

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ with the command
 
 ## Building and testing
 
-Build ArangoDB with the current build options by issueing
+Build ArangoDB with the current build options by issuing
 
     buildStaticArangoDB
 
@@ -201,11 +201,43 @@ build enterprise edition (enterprise) or community version (community)
 
     parallelism <PARALLELSIM>
 
-if supported, set numer of concurrent builds to `PARALLELISM`
+if supported, set number of concurrent builds to `PARALLELISM`
 
 ## Testing
 
 ## Documentation
+
+To build the Docker documentation container from the current oskar
+working tree, run:
+
+    ./scripts/buildContainerDocumentation <IMAGE_NAME>
+
+The [official image](https://hub.docker.com/r/arangodb/arangodb-documentation)
+is called `arangodb/arangodb-documentation`.
+
+To rebuild the container after Gitbook plugins were changed externally,
+it is required to invalidate the cache with  `--force-update`:
+
+    ./scripts/buildContainerDocumentation arangodb/arangodb-documentation --force-update
+
+If you want to inspect the filesystem in the container, you can do:
+
+    docker run -it --entrypoint=/bin/bash arangodb/arangodb-documentation
+    ls /
+
+Hit `Ctrl+D` to exit.
+
+To build the documentation with the `arangodb/arangodb-documentation` image, run:
+
+    ./scripts/buildDocumentation
+
+See the comments in the [buildDocumentation](./scripts/buildDocumentation)
+script for options.
+
+Changes to the container should first be tested and merged into the oskar
+master branch. Then the image can be (re-)built and published for Jenkins:
+
+    docker push arangodb/arangodb-documentation
 
 ## Packaging
 

--- a/README.md
+++ b/README.md
@@ -227,12 +227,29 @@ If you want to inspect the filesystem in the container, you can do:
 
 Hit `Ctrl+D` to exit.
 
+If you want to start the container with the oskar directory mounted
+(including `work/ArangoDB/`) then specify the path mapping with `-v`:
+
+    docker run -v "/home/<NAME>/oskar:/oskar" ...
+
 To build the documentation with the `arangodb/arangodb-documentation` image, run:
 
     ./scripts/buildDocumentation
 
+If you don't want to generate the examples and `api-docs.json` and build
+only a subset of books, run:
+
+    ./scripts/buildDocumentation --skip-examples --skip-swagger --books "AQL Cookbook"
+
+The resulting files are located in `~/oskar/work/build-documentation/`
+(if your oskar directory is in your user folder). You may use
+[serve](https://github.com/zeit/serve) to view the generated website version
+of the documentation:
+
+    serve ~/oskar/work/build-documentation/books_html/
+
 See the comments in the [buildDocumentation](./scripts/buildDocumentation)
-script for options.
+script for more options.
 
 Changes to the container should first be tested and merged into the oskar
 master branch. Then the image can be (re-)built and published for Jenkins:

--- a/containers/documentation.docker/buildLib
+++ b/containers/documentation.docker/buildLib
@@ -4,6 +4,39 @@
 ### HELPER FUNCTIONS ###########################################################
 ################################################################################
 
+first_version_is_less() {
+    local left=${1%%-*}
+    local right=${2%%-*}
+    declare -l -a left_arr
+    declare -l -a right_arr
+
+    IFS='.' read -r -a left_arr <<<"$left"
+    IFS='.' read -r -a right_arr <<<"$right"
+
+    local len=${#left_arr[@]}
+    local other_len=${#right_arr[@]}
+    if (( other_len < len )); then
+        len=other_len
+    fi
+
+    local i
+    for (( i=0; i < len; i++ )); do
+        left=${left_arr[$i]}
+        right=${right_arr[$i]}
+        if (( left == right )); then
+            continue
+        elif (( left > right )); then
+            return 1
+        else
+            return 0
+        fi
+    done
+
+    # Return false because we test a strict less.
+    # Set this to 0 for less-equal.
+    return 1
+}
+
 # a grep that does not fail if there are no matches
 # can be used with multiple pipes where grep is not
 # expected to macht always something

--- a/containers/documentation.docker/buildLib
+++ b/containers/documentation.docker/buildLib
@@ -33,7 +33,7 @@ minimum_version() {
     done
 
     # Return false because we test for greater-equal.
-    # Set this to 1 strict greater.
+    # Set this to 1 for a strict greater.
     return 0
 }
 

--- a/containers/documentation.docker/buildLib
+++ b/containers/documentation.docker/buildLib
@@ -158,14 +158,18 @@ run_gitbook(){
         section "book.json" | sed 's/-/#/g'
         cat book.json
 
+	local plugins=$(mktemp)
+	cat "$book_src/book.json" | sed -e 's/@GPRIORITY@/0/' | jq .plugins > "$plugins" \
+            || ferr "failed to extract plugins from source books.json. Make sure it contains valid json!"
+
         $c && section "diff" | sed 's/-/#/g'
-        $c && diff "$book_src/book.json" "$cache/book.json.original"
+        $c && diff "$plugins" "$cache/book.json.plugins"
         $c && echo "plugins must not differ"
 
         section "modules" | sed 's/-/#/g'
         ls -lisah node_modules
         section "" | sed 's/-/=/g'
-        echo "try to run ./scripts/buildContainerDocumentation --force-update if modules are missing"
+        echo "try to run ./scripts/buildContainerDocumentation --force-update if plugins/modules are missing"
         ferr "running gitbook failed"
     fi
 }

--- a/containers/documentation.docker/buildLib
+++ b/containers/documentation.docker/buildLib
@@ -4,7 +4,7 @@
 ### HELPER FUNCTIONS ###########################################################
 ################################################################################
 
-first_version_is_less() {
+minimum_version() {
     local left=${1%%-*}
     local right=${2%%-*}
     declare -l -a left_arr
@@ -25,16 +25,16 @@ first_version_is_less() {
         right=${right_arr[$i]}
         if (( left == right )); then
             continue
-        elif (( left > right )); then
+        elif (( left < right )); then
             return 1
         else
             return 0
         fi
     done
 
-    # Return false because we test a strict less.
-    # Set this to 0 for less-equal.
-    return 1
+    # Return false because we test for greater-equal.
+    # Set this to 1 strict greater.
+    return 0
 }
 
 # a grep that does not fail if there are no matches

--- a/containers/documentation.docker/build_documentation
+++ b/containers/documentation.docker/build_documentation
@@ -130,7 +130,7 @@ newVersionNumber="$( tr -d '\r\n' < "$ARANGO_SOURCE/VERSION" )"
 
 # Skip Drivers book for versions older than 3.4, which do not have it
 if first_version_is_less "${newVersionNumber}" "3.4"; then
-    ALLBOOKS = $(${ALLBOOKS} | sed -e 's/Drivers//')
+    ALLBOOKS=$(echo "${ALLBOOKS}" | sed -e 's/Drivers//')
 fi
 
 # If ../../VERSION contains the string "devel" the current date will be added to all pages containing the version.

--- a/containers/documentation.docker/build_documentation
+++ b/containers/documentation.docker/build_documentation
@@ -128,8 +128,8 @@ TRIPPLETICS='```'
 
 newVersionNumber="$( tr -d '\r\n' < "$ARANGO_SOURCE/VERSION" )"
 
-# Skip Drivers book for versions older than 3.4, which do not have it
-if ! first_version_is_less "${newVersionNumber}" "3.4"; then
+# Include Drivers book from version 3.4 on
+if minimum_version "${newVersionNumber}" "3.4"; then
     ALLBOOKS="${ALLBOOKS} Drivers"
 fi
 

--- a/containers/documentation.docker/build_documentation
+++ b/containers/documentation.docker/build_documentation
@@ -122,15 +122,15 @@ section "" | sed 's/-/=/g'
 
 
 #### GLOBAL VARS THAT SHOULD NOT BE MODIFIED BY USERS ########################################################
-ALLBOOKS="HTTP AQL Cookbook Drivers Manual"
+ALLBOOKS="HTTP AQL Cookbook Manual"
 OTHER_MIME="pdf epub mobi"
 TRIPPLETICS='```'
 
 newVersionNumber="$( tr -d '\r\n' < "$ARANGO_SOURCE/VERSION" )"
 
 # Skip Drivers book for versions older than 3.4, which do not have it
-if first_version_is_less "${newVersionNumber}" "3.4"; then
-    ALLBOOKS=$(echo "${ALLBOOKS}" | sed -e 's/Drivers//')
+if ! first_version_is_less "${newVersionNumber}" "3.4"; then
+    ALLBOOKS="${ALLBOOKS} Drivers"
 fi
 
 # If ../../VERSION contains the string "devel" the current date will be added to all pages containing the version.
@@ -259,7 +259,7 @@ function build_book() {
     # string e.g. numbers. Otherwise jq will fail. So if something goes
     # wrong here you probably need antoher sed command
     cat "$book_src/book.json" | sed -e 's/@GPRIORITY@/0/' | jq .plugins > "$this" \
-        || ferr "failed to extract plugins form books.json. Make sure it contains vaild json!"
+        || ferr "failed to extract plugins from source books.json. Make sure it contains valid json!"
 
     unset book_cache
     while read -r file; do

--- a/containers/documentation.docker/build_documentation
+++ b/containers/documentation.docker/build_documentation
@@ -274,9 +274,9 @@ function build_book() {
     rm "$this"
 
     local msg="failed to detect cache - book.json of $book_name\n"
-          msg="Plugins do match any cached version."
-          msg="If you use new plugins make sure to add this branch"
-          msg="to ARANGO_SUPPORTED_BRANCHES and rebuild the doc container."
+          msg+="Plugins do not match any cached version."
+          msg+="If you use new plugins make sure to add this branch"
+          msg+="to ARANGO_SUPPORTED_BRANCHES and rebuild the doc container."
     [[ -v book_cache ]] || ferr -e "$msg"
 
 

--- a/containers/documentation.docker/build_documentation
+++ b/containers/documentation.docker/build_documentation
@@ -117,15 +117,23 @@ section "" | sed 's/-/=/g'
 section "ArangoDB Documenation Build script" | sed 's/-/=/g'
 section "" | sed 's/-/=/g'
 
+# pull in build lib - this lib contains most of checks
+. "$script_dir/buildLib" || ferr "failed to source buildLib"
+
+
 #### GLOBAL VARS THAT SHOULD NOT BE MODIFIED BY USERS ########################################################
-ALLBOOKS="HTTP AQL Cookbook Drivers" #TODO reactivate Manual
-ALLBOOKS="HTTP AQL Manual Cookbook Drivers"
+ALLBOOKS="HTTP AQL Cookbook Drivers Manual"
 OTHER_MIME="pdf epub mobi"
 TRIPPLETICS='```'
 
 newVersionNumber="$( tr -d '\r\n' < "$ARANGO_SOURCE/VERSION" )"
-#If ../../VERSION contains the string "devel" the current date will be added to all pages containing the version.
 
+# Skip Drivers book for versions older than 3.4, which do not have it
+if first_version_is_less "${newVersionNumber}" "3.4"; then
+    ALLBOOKS = $(${ALLBOOKS} | sed -e 's/Drivers//')
+fi
+
+# If ../../VERSION contains the string "devel" the current date will be added to all pages containing the version.
 if echo "${newVersionNumber}" | grep -q devel; then
     VERSION="${newVersionNumber} $(date +' %d. %b %Y ')"
     RELEASE_DIRECTORY=devel
@@ -151,9 +159,6 @@ if test -z "${INSTALLED_GITBOOK_VERSION}"; then
 fi
 GITBOOK_ARGS=(--gitbook "${INSTALLED_GITBOOK_VERSION}")
 #### GLOBAL VARS THAT SHOULD NOT BE MODIFIED BY USERS - END ########################################################
-
-# pull in build lib - this lib contains most of checks
-. "$script_dir/buildLib" || ferr "failed to source buildLib"
 
 
 ################################################################################


### PR DESCRIPTION
- Add helper first_version_is_less() and exception for Drivers book in versions < 3.4
- Changed default order of ALLBOOKS to build Manual last
- Describe how to build and use Docker documentation container

A local test build on C9 of this patch and this 3.2 PR: https://github.com/arangodb/arangodb/pull/7737
... was successful. A devel build also went through.