### PR TITLE
Doc - Do not delete output folders if keep_old=true

### DIFF
--- a/containers/documentation.docker/build_documentation
+++ b/containers/documentation.docker/build_documentation
@@ -130,7 +130,7 @@ newVersionNumber="$( tr -d '\r\n' < "$ARANGO_SOURCE/VERSION" )"
 
 # Include Drivers book from version 3.4 on
 if minimum_version "${newVersionNumber}" "3.4"; then
-    ALLBOOKS="${ALLBOOKS} Drivers"
+    ALLBOOKS="Drivers ${ALLBOOKS}"
 fi
 
 # If ../../VERSION contains the string "devel" the current date will be added to all pages containing the version.
@@ -412,7 +412,7 @@ main(){
     done
 
     # keep or delete files from last build
-    if $keep_old; then
+    if ! $keep_old; then
         rm -fr "$ARANGO_BUILD_DOC_OUT" || ferr "could not delete books output dir"
         rm -fr "$ARANGO_BUILD_DOC_PRE" || ferr "could not delete ppdir dir"
     fi


### PR DESCRIPTION
Looks like the logic was reversed and it would keep the files by default when it should delete them.

Also changed: prepend Drivers book, so that Manual is the last to be built and we catch crosslink errors earlier.