### PR TITLE
Doc - Do not prepend index.html to links in anchor check

### DIFF
--- a/containers/documentation.docker/buildLib
+++ b/containers/documentation.docker/buildLib
@@ -783,9 +783,12 @@ cross_out_check_dangling_anchors() {
 
         $debug_anchors && debug $check_filename
 
-        if [[ -d "$check_filename" ]]; then
-            check_filename="${check_filename}/index.html"
-        fi
+        # Browsers will resolve links like Foo/ to Foo/index.html automatically,
+	# but our desired format is Foo/README.md in the source code and the
+	# old Jenkins does not append index.html in tests, thus we disable it here
+        #if [[ -d "$check_filename" ]]; then
+        #    check_filename="${check_filename}/index.html"
+        #fi
 
         if  ! [[ -f "/tmp/tags/${check_filename}" ]]; then
             err "File '/tmp/tags/${check_filename}' referenced by '$anchor' doesn't exist."


### PR DESCRIPTION
Ref: https://github.com/arangodb/planning/issues/3674

Currently, a docu build may succeed in new Jenkins, but fail in old Jenkins. This PR adjusts the anchor check to match the behavior of old Jenkins, so that we catch link errors in our test builds on new Jenkins already. The links do work in browsers, but we want fully qualified links in source.

To test this PR, we can use the commit before: https://github.com/arangodb/arangodb/commit/fcc1700d334c89693d992906b7d4e03f31f09017