### PR TITLE
try to add log-id-check

### DIFF
--- a/scripts/lib/tests.fish
+++ b/scripts/lib/tests.fish
@@ -56,6 +56,18 @@ function createReport
       grep ERROR "jslint.log" > "$INNERWORKDIR/jslint.out/testfailures.txt"
     end
   end
+
+  # this is the logids output
+  if test -e "logids.log"
+    if grep ERROR "logids.log"
+      set -g result BAD
+      echo Bad result in logids
+      echo Bad result in logids >> testProtocol.txt
+      set badtests $badtests "Bad result in logids"
+      mkdir "$INNERWORKDIR/logids.out/"
+      grep ERROR "logids.log" > "$INNERWORKDIR/logids.out/testfailures.txt"
+    end
+  end
  
   popd
   echo $result >> testProtocol.txt

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -53,9 +53,11 @@ function launchSingleTests
   end
 
   function logids
-    if test $VERBOSEOSKAR = On ; echo Launching Log-Id-Check $argv "($launchCount)" ; end
-    echo utils/checkLogIds.py
-    utils/checkLogIds.py > $TMPDIR/logids.log &
+    if test -f utils/checkLogIds.py;
+        if test $VERBOSEOSKAR = On ; echo Launching Log-Id-Check $argv "($launchCount)" ; end
+        echo utils/checkLogIds.py
+        utils/checkLogIds.py > $TMPDIR/logids.log &
+    end
   end
 
   function test1

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -144,7 +144,7 @@ function launchSingleTests
     case 37 ; test1         ssl_server ""
     case 38 ; test1         version ""
     case 39 ; test1         active_failover ""
-    case 40 ; test1         logids ""
+    case 40 ; logids
     case '*' ; return 0
   end
   set -g launchCount (math $launchCount + 1)

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -52,6 +52,12 @@ function launchSingleTests
     utils/jslint.sh > $TMPDIR/jslint.log &
   end
 
+  function logids
+    if test $VERBOSEOSKAR = On ; echo Launching Log-Id-Check $argv "($launchCount)" ; end
+    echo utils/checkLogIds.py
+    utils/checkLogIds.py > $TMPDIR/logids.log &
+  end
+
   function test1
     if test $VERBOSEOSKAR = On ; echo Launching $argv "($launchCount)" ; end
 
@@ -138,6 +144,7 @@ function launchSingleTests
     case 37 ; test1         ssl_server ""
     case 38 ; test1         version ""
     case 39 ; test1         active_failover ""
+    case 40 ; test1         logids ""
     case '*' ; return 0
   end
   set -g launchCount (math $launchCount + 1)


### PR DESCRIPTION
The test is at the very end to ensure it does not disturb other tests. If enterprise is not available the test result is not reliable. Therefor we would build non-enterprise configurations with false-positives anyway, as we do not have something like an id database and we decided against checking out enterprise when building the community edition. 

Questions:
Do I need to create a new container?