### PR TITLE
split audit tests in audit_client and audit_server

### DIFF
--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -167,6 +167,8 @@ function launchSingleTests
     case 66 ; test1         readOnly ""
     case 67 ; test1         upgrade ""
     case 68 ; test1         version ""
+    case 69 ; test1         audit_client ""
+    case 70 ; test1         audit_server ""
     case '*' ; return 0
   end
   set -g launchCount (math $launchCount + 1)

--- a/scripts/runFullTests.ps1
+++ b/scripts/runFullTests.ps1
@@ -78,6 +78,8 @@ Function global:registerSingleTests()
     registerTest -testname "readOnly"
     registerTest -testname "upgrade"
     registerTest -testname "version"
+    registerTest -testname "audit_client"
+    registerTest -testname "audit_server"
     comm
 }
 


### PR DESCRIPTION
In devel/3.5 we now have separate tests `audit_client` and `audit_server`.
This PR adds these to oskar.
These test suites have been blacklisted in 3.2, 3.3 and 3.4, so this shouldn't do any harm.