### PR TITLE
Set parallelism globally (Linux, macOS)

### DIFF
--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -928,4 +928,4 @@ end
 ## set PARALLELISM in a sensible way
 ## #############################################################################
 
-parallelism (math (grep processor /proc/cpuinfo | wc -l) "*" 2)
+parallelism (nproc)

--- a/helper.mac.fish
+++ b/helper.mac.fish
@@ -237,4 +237,4 @@ function findCompilerVersion
   gcc -v ^| tail -1 | awk '{print $3}'
 end
 
-parallelism 4
+parallelism (sysctl -n hw.logicalcpu)

--- a/jenkins/buildMaintainerMac.fish
+++ b/jenkins/buildMaintainerMac.fish
@@ -5,7 +5,6 @@ lockDirectory ; updateOskar ; clearResults
 rocksdb ; cluster ; maintainerOn
 
 eval $EDITION
-parallelism 8
 
 echo "--------------------------------------------------------------------------------"
 showConfig

--- a/jenkins/runAsanNightlyTest.fish
+++ b/jenkins/runAsanNightlyTest.fish
@@ -6,7 +6,6 @@ lockDirectory ; updateOskar ; clearResults
 eval $EDITION ; eval $STORAGE_ENGINE ; eval $TEST_SUITE ; skipGrey
 
 switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
-and parallelism 8
 and compiler "$COMPILER_VERSION"
 and asanOn
 and oskar1

--- a/jenkins/runCatchTestMac.fish
+++ b/jenkins/runCatchTestMac.fish
@@ -5,7 +5,6 @@ lockDirectory ; updateOskar ; clearResults
 
 eval $EDITION
 catchtest
-parallelism 24
 
 echo "--------------------------------------------------------------------------------"
 showConfig

--- a/jenkins/runFullNightlyTest.fish
+++ b/jenkins/runFullNightlyTest.fish
@@ -5,12 +5,7 @@ lockDirectory ; updateOskar ; clearResults
 
 eval $EDITION ; eval $STORAGE_ENGINE ; eval $TEST_SUITE ; skipGrey
 
-if test -z "$PARALLELISM_FULL_TEST"
-  set -g PARALLELISM_FULL_TEST 20
-end
-
 switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
-and parallelism "$PARALLELISM_FULL_TEST"
 and compiler "$COMPILER_VERSION"
 and oskar1Full
 

--- a/jenkins/runFullNightlyTestMac.fish
+++ b/jenkins/runFullNightlyTestMac.fish
@@ -4,8 +4,6 @@ source jenkins/helper.jenkins.fish ; prepareOskar
 lockDirectory ; updateOskar ; clearResults
 
 eval $EDITION ; eval $STORAGE_ENGINE ; eval $TEST_SUITE ; skipGrey
-set logical_cores (sysctl -n hw.ncpu)
-parallelism (math "$logical_cores*2")
 
 echo "--------------------------------------------------------------------------------"
 showConfig

--- a/jenkins/runFullNightlyTestOnlyGrey.fish
+++ b/jenkins/runFullNightlyTestOnlyGrey.fish
@@ -5,12 +5,7 @@ lockDirectory ; updateOskar ; clearResults
 
 eval $EDITION ; eval $STORAGE_ENGINE ; eval $TEST_SUITE ; onlyGreyOn
 
-if test -z "$PARALLELISM_FULL_TEST"
-  set -g PARALLELISM_FULL_TEST 20
-end
-
 switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
-and parallelism "$PARALLELISM_FULL_TEST"
 and compiler "$COMPILER_VERSION"
 and oskar1Full
 

--- a/jenkins/runFullNightlyTestWithGrey.fish
+++ b/jenkins/runFullNightlyTestWithGrey.fish
@@ -5,12 +5,7 @@ lockDirectory ; updateOskar ; clearResults
 
 eval $EDITION ; eval $STORAGE_ENGINE ; eval $TEST_SUITE ; includeGrey; includeNondeterministic; includeTimeCritical
 
-if test -z "$PARALLELISM_FULL_TEST"
-  set -g PARALLELISM_FULL_TEST 20
-end
-
 switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
-and parallelism "$PARALLELISM_FULL_TEST"
 and compiler "$COMPILER_VERSION"
 and oskar1Full
 

--- a/jenkins/runPRtestMac.fish
+++ b/jenkins/runPRtestMac.fish
@@ -4,8 +4,6 @@ source jenkins/helper.jenkins.fish ; prepareOskar
 lockDirectory ; updateOskar ; clearResults
 
 eval $EDITION ; eval $STORAGE_ENGINE ; eval $TEST_SUITE ; skipGrey
-set logical_cores (sysctl -n hw.ncpu)
-parallelism (math "$logical_cores*2")
 
 echo "--------------------------------------------------------------------------------"
 showConfig

--- a/jenkins/runQuickyTestMac.fish
+++ b/jenkins/runQuickyTestMac.fish
@@ -16,12 +16,6 @@ or begin
   exit 1
 end
 
-if test -z "$PARALLELISM_QUICKY_TEST"
-  set -g PARALLELISM_QUICKY_TEST 20
-end
-
-parallelism "$PARALLELISM_QUICKY_TEST"
-
 enterprise ; rocksdb ; cluster ; skipGrey
 
 oskar1


### PR DESCRIPTION
Globally set parallelism as number of logical cores available.

For Windows direct commit was done: https://github.com/arangodb/oskar/commit/465edcc55da197efa2ff7d66e87298ae5e8d0dff