### PR TITLE
Extend PR tests timeout

### DIFF
--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -166,17 +166,17 @@ switch $TESTSUITE
   case "cluster"
     resetLaunch 4
     and if test "$ASAN" = "On"
-      waitOrKill 14400 launchClusterTests
+      waitOrKill 16800 launchClusterTests
     else
-      waitOrKill 3600 launchClusterTests
+      waitOrKill 4200 launchClusterTests
     end
     createReport
   case "single"
     resetLaunch 1
     and if test "$ASAN" = "On"
-      waitOrKill 14400 launchSingleTests
+      waitOrKill 15600 launchSingleTests
     else
-      waitOrKill 3600 launchSingleTests
+      waitOrKill 3900 launchSingleTests
     end
     createReport
   case "catchtest"

--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -10,7 +10,7 @@ Function global:registerSingleTests()
 
     Write-Host "Registering tests..."
 
-    $global:TESTSUITE_TIMEOUT = 3600
+    $global:TESTSUITE_TIMEOUT = 3900
 
     registerTest -testname "replication_static" -weight 2
     registerTest -testname "shell_server"
@@ -69,7 +69,7 @@ Function global:registerClusterTests()
     noteStartAndRepoState
     Write-Host "Registering tests..."
 
-    $global:TESTSUITE_TIMEOUT = 3600
+    $global:TESTSUITE_TIMEOUT = 4200
 
     registerTest -cluster $true -testname "agency"
     registerTest -cluster $true -testname "shell_server"


### PR DESCRIPTION
+5m for single tests, +10m for cluster tests.