### PR TITLE
added missing tests, which were not executed in cluster before

### DIFF
--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -166,6 +166,8 @@ set CT "$CT""500,runClusterTest1 authentication 2 --testBuckets 3/2 --dumpAgency
 set CT "$CT""750,runClusterTest1 http_server - --dumpAgencyOnError true\n"
 set CT "$CT""1000,runClusterTest1 server_permissions - --dumpAgencyOnError true\n"
 set CT "$CT""1000,runClusterTest1 ssl_server - --dumpAgencyOnError true\n"
+set CT "$CT""250,runClusterTest1 audit_client - --dumpAgencyOnError true\n"
+set CT "$CT""250,runClusterTest1 audit_server - --dumpAgencyOnError true\n"
 set CT "$CT""500,runClusterTest1 server_http - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 dump - --dumpAgencyOnError true\n"
 set CT "$CT""500,runClusterTest1 client_resilience - --dumpAgencyOnError true\n"

--- a/scripts/runFullTests.ps1
+++ b/scripts/runFullTests.ps1
@@ -123,6 +123,8 @@ Function global:registerClusterTests()
     registerTest -cluster $true -testname "dump_maskings"
     registerTest -cluster $true -testname "dump_multiple"
     registerTest -cluster $true -testname "server_http"
+    registerTest -cluster $true -testname "audit_client"
+    registerTest -cluster $true -testname "audit_server"
     # registerTest -cluster $true -testname "agency" -weight 2
     # Note that we intentionally do not register the hot_backup test here,
     # since it is currently not supported on Windows. The reason is that

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -124,6 +124,8 @@ set CT "$CT""1500,runClusterTest1 shell_server_aql 15 --testBuckets 16/15 --dump
 set CT "$CT""500,runClusterTest1 server_http - --dumpAgencyOnError true\n"
 set CT "$CT""1000,runClusterTest1 server_permissions - --dumpAgencyOnError true\n"
 set CT "$CT""1000,runClusterTest1 ssl_server - --dumpAgencyOnError true\n"
+set CT "$CT""250,runClusterTest1 audit_client - --dumpAgencyOnError true\n"
+set CT "$CT""250,runClusterTest1 audit_server - --dumpAgencyOnError true\n"
 set CT "$CT""600,runClusterTest1 resilience_move - --dumpAgencyOnError true\n"
 set CT "$CT""750,runClusterTest1 resilience_failover - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 resilience_sharddist - --dumpAgencyOnError true\n"

--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -90,6 +90,8 @@ Function global:registerClusterTests()
     registerTest -cluster $true -testname "shell_server_aql" -index "4" -bucket "5/4"
     registerTest -cluster $true -testname "server_http"
     registerTest -cluster $true -testname "ssl_server"
+    registerTest -cluster $true -testname "audit_client"
+    registerTest -cluster $true -testname "audit_server"
     # Note that we intentionally do not register the hot_backup test here,
     # since it is currently not supported on Windows. The reason is that
     # the testing framework does not support automatic restarts of instances


### PR DESCRIPTION
Adds tests `audit_client` and `audit_server`, which are currently not run in cluster.

*don't merge yet, as the testsuites are currently broken in cluster*.

If all tests pass, merging should be done in the following order:
1) https://github.com/arangodb/enterprise/pull/306
2) https://github.com/arangodb/arangodb/pull/9886
3) https://github.com/arangodb/enterprise/pull/307
4) https://github.com/arangodb/arangodb/pull/9887
5) https://github.com/arangodb/oskar/pull/173
