### PR TITLE
fix logId check for invalid IDs

### DIFF
--- a/helper.fish
+++ b/helper.fish
@@ -1383,9 +1383,9 @@ function checkLogId
   or begin popd; return 1; end
 
   set -l ids (find lib arangod arangosh enterprise -name "*.cpp" -o -name "*.h" \
-    | xargs grep -h 'LOG_\(TOPIC\|TRX\|TOPIC_IF\)("[a-z0-9]*"' \
+    | xargs grep -h 'LOG_\(TOPIC\|TRX\|TOPIC_IF\)("[^\"]*"' \
     | grep -v 'LOG_DEVEL' \
-    | sed -e 's:^.*LOG_[^(]*("\([a-z0-9]*\)".*:\1:')
+    | sed -e 's:^.*LOG_[^(]*("\([^\"]*\)".*:\1:')
 
   set -l duplicate (echo $ids | tr " " "\n" | sort | uniq -d)
 

--- a/helper.fish
+++ b/helper.fish
@@ -1383,8 +1383,9 @@ function checkLogId
   or begin popd; return 1; end
 
   set -l ids (find lib arangod arangosh enterprise -name "*.cpp" -o -name "*.h" \
-    | xargs grep -h 'LOG_\(TOPIC\|TRX\|TOPIC_IF\)("[a-f0-9]*"' \
-    | sed -e 's:^.*LOG_[^(]*("\([a-f0-9]*\)".*:\1:')
+    | xargs grep -h 'LOG_\(TOPIC\|TRX\|TOPIC_IF\)("[a-z0-9]*"' \
+    | grep -v 'LOG_DEVEL' \
+    | sed -e 's:^.*LOG_[^(]*("\([a-z0-9]*\)".*:\1:')
 
   set -l duplicate (echo $ids | tr " " "\n" | sort | uniq -d)
 


### PR DESCRIPTION
The current implementation of the logId check only finds too long or too short logIds, but it doesn't find logIds with invalid characters in them.