### PR TITLE
enable permissions test

### DIFF
--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -136,6 +136,7 @@ set CT "$CT""250,runClusterTest1 dump_maskings - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 dump_multiple - --dumpAgencyOnError true\n"
 set CT "$CT""750,runClusterTest1 http_server - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 hot_backup -\n"
+set CT "$CT""500,runClusterTest1 permissions -\n"
 
 set -g CTS (echo -e $CT | fgrep , | sort -rn | awk -F, '{print $2}')
 set -g CTL (count $CTS)

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -51,6 +51,7 @@ set ST "$ST""500,runSingleTest2 replication_ongoing_global -\n"
 set ST "$ST""250,runSingleTest2 replication_ongoing_global_spec -\n"
 set ST "$ST""500,runSingleTest2 replication_sync -\n"
 set ST "$ST""250,runSingleTest1 hot_backup -\n"
+set ST "$ST""500,runSingleTest1 permissions -\n"
 
 set -g STS (echo -e $ST | fgrep , | sort -rn | awk -F, '{print $2}')
 set -g STL (count $STS)
@@ -136,7 +137,6 @@ set CT "$CT""250,runClusterTest1 dump_maskings - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 dump_multiple - --dumpAgencyOnError true\n"
 set CT "$CT""750,runClusterTest1 http_server - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 hot_backup -\n"
-set CT "$CT""500,runClusterTest1 permissions -\n"
 
 set -g CTS (echo -e $CT | fgrep , | sort -rn | awk -F, '{print $2}')
 set -g CTL (count $CTS)

--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -54,6 +54,7 @@ Function global:registerSingleTests()
     registerTest -testname "version"
     registerTest -testname "audit_client"
     registerTest -testname "audit_server"
+    registerTest -testname "permissions"
     # Note that we intentionally do not register the hot_backup test here,
     # since it is currently not supported on Windows. The reason is that
     # the testing framework does not support automatic restarts of instances


### PR DESCRIPTION
Enable single server `permissions` test for PR tests.
It is not necessary to run this test in cluster mode as it checks the arangosh only.