### PR TITLE
docker entrypoint: can override conf with envvars

### DIFF
--- a/containers/arangodb35.docker/entrypoint.sh
+++ b/containers/arangodb35.docker/entrypoint.sh
@@ -7,6 +7,7 @@ set -e
 ## example:
 ##  ARANGOD_CONF_LOG_LEVEL=debug
 ##   => update [log] section with "level = debug"
+## Multi-line values will be split in multiple occurences of the same option
 updateconf() {
   tmpconfdir=/tmp/arangoconf
   conffile=/tmp/arangod.conf
@@ -54,9 +55,11 @@ updateconf() {
           sed -i 's/^\('"$option"' = .*\)/# \1/' "$file"
         fi
 
-        # Add option
-        echo "$option = $value" >> "$file"
-
+        # Add option - split by newline
+        echo "$value" \
+        | while read -r value_i; do
+          echo "$option = $value_i" >> "$file"
+        done
       done
 
   ## Generate a new config file from updated section files

--- a/containers/arangodb35.docker/entrypoint.sh
+++ b/containers/arangodb35.docker/entrypoint.sh
@@ -28,6 +28,7 @@ updateconf() {
   done < "$conffile"
 
   ## cycle through all ARANGOCONF* var / value pairs
+  #  lowercase values while we're here because it's easy with awk
   awk 'BEGIN{for(v in ENVIRON) print tolower(v) " " ENVIRON[v]}' \
     | grep -e '^arangoconf' \
     | while read -r var value; do
@@ -38,6 +39,7 @@ updateconf() {
         # :: so let's split it in 2 separate parsings
         section=$(echo "$var" | sed -n 's/arangoconf_\([^_]*\)_\(.*\)/\1/p')
         param=$(echo "$var" | sed -n 's/arangoconf_\([^_]*\)_\(.*\)/\2/p')
+        param=$(echo "$param" | sed 's/_/-/') # env vars use '-' but param names use '-'
 
         # :: array not available in POSIX sh - let's hope sections are never duplicate
         file="$(ls "$tmpconfdir"/[0-9][0-9]-"$section" 2>/dev/null || true)"

--- a/containers/arangodb35.docker/entrypoint.sh
+++ b/containers/arangodb35.docker/entrypoint.sh
@@ -48,15 +48,14 @@ updateconf() {
         if [ ! -f "$file" ]; then # section (file) not yet existing
           file="$tmpconfdir"/99-"$section"
           echo "[$section]" >> "$file"
-          echo "$option = $value" >> "$file"
-
-        else # section already existing
-          if grep -qe "^$option = " "$file"; then # option already existing - replace
-            sed -i 's/^'"$option"' = .*/'"$option"' = '"$value"'/g' "$file"
-          else # option not yet existing - just add
-            echo "$option = $value" >> "$file"
-          fi
         fi
+
+        if grep -qe "^$option = " "$file"; then # option already existing - comment it
+          sed -i 's/^\('"$option"' = .*\)/# \1/' "$file"
+        fi
+
+        # Add option
+        echo "$option = $value" >> "$file"
 
       done
 

--- a/containers/arangodb35.docker/entrypoint.sh
+++ b/containers/arangodb35.docker/entrypoint.sh
@@ -3,9 +3,9 @@ set -e
 
 ## Update conf from generic env vars
 ## env vars syntax:
-##  ARANGOCONF_SECTION_OPTION=VALUE
+##  ARANGOD_CONF_SECTION_OPTION=VALUE
 ## example:
-##  ARANGOCONF_LOG_LEVEL=debug
+##  ARANGOD_CONF_LOG_LEVEL=debug
 ##   => update [log] section with "level = debug"
 updateconf() {
   tmpconfdir=/tmp/arangoconf
@@ -27,18 +27,18 @@ updateconf() {
       echo "$line" >> "$(printf "%s/%02d-%s" "$tmpconfdir" "$currentnumber" "$currentfile")"
   done < "$conffile"
 
-  ## cycle through all ARANGOCONF* var / value pairs
+  ## cycle through all ARANGOD_CONF* var / value pairs
   #  lowercase values while we're here because it's easy with awk
   awk 'BEGIN{for(v in ENVIRON) print tolower(v) " " ENVIRON[v]}' \
-    | grep -e '^arangoconf' \
+    | grep -e '^arangod_conf' \
     | while read -r var value; do
 
         ## Extract section name and option name from var name.
         # :: In POSIX sh, process substitution is undefined. In bash we would do:
-        # :: $ read -r section option < <(echo "$var" | sed -n 's/ARANGOCONF_\([^_]*\)_\(.*\)/\1 \2/p')
+        # :: $ read -r section option < <(echo "$var" | sed -n 's/arangod_conf_\([^_]*\)_\(.*\)/\1 \2/p')
         # :: so let's split it in 2 separate parsings
-        section=$(echo "$var" | sed -n 's/arangoconf_\([^_]*\)_\(.*\)/\1/p')
-        option=$(echo "$var" | sed -n 's/arangoconf_\([^_]*\)_\(.*\)/\2/p')
+        section=$(echo "$var" | sed -n 's/arangod_conf_\([^_]*\)_\(.*\)/\1/p')
+        option=$(echo "$var" | sed -n 's/arangod_conf_\([^_]*\)_\(.*\)/\2/p')
         option=$(echo "$option" | sed 's/_/-/') # env vars use '_' but option names use '-'
         if [ "$section" = "" ] || [ "$option" = "" ]; then continue; fi # bypass invalid vars
 

--- a/containers/arangodb35.docker/entrypoint.sh
+++ b/containers/arangodb35.docker/entrypoint.sh
@@ -40,6 +40,7 @@ updateconf() {
         section=$(echo "$var" | sed -n 's/arangoconf_\([^_]*\)_\(.*\)/\1/p')
         param=$(echo "$var" | sed -n 's/arangoconf_\([^_]*\)_\(.*\)/\2/p')
         param=$(echo "$param" | sed 's/_/-/') # env vars use '_' but param names use '-'
+        if [ "$section" = "" ] || [ "$param" = "" ]; then continue; fi # bypass invalid vars
 
         # :: array not available in POSIX sh - let's hope sections are never duplicate
         file="$(ls "$tmpconfdir"/[0-9][0-9]-"$section" 2>/dev/null || true)"

--- a/containers/arangodb35.docker/entrypoint.sh
+++ b/containers/arangodb35.docker/entrypoint.sh
@@ -39,7 +39,7 @@ updateconf() {
         # :: so let's split it in 2 separate parsings
         section=$(echo "$var" | sed -n 's/arangoconf_\([^_]*\)_\(.*\)/\1/p')
         param=$(echo "$var" | sed -n 's/arangoconf_\([^_]*\)_\(.*\)/\2/p')
-        param=$(echo "$param" | sed 's/_/-/') # env vars use '-' but param names use '-'
+        param=$(echo "$param" | sed 's/_/-/') # env vars use '_' but param names use '-'
 
         # :: array not available in POSIX sh - let's hope sections are never duplicate
         file="$(ls "$tmpconfdir"/[0-9][0-9]-"$section" 2>/dev/null || true)"

--- a/containers/arangodb35.docker/entrypoint.sh
+++ b/containers/arangodb35.docker/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 ## Update conf from generic env vars
 ## env vars syntax:
-##  ARANGOCONF_SECTION_PARAMETER=VALUE
+##  ARANGOCONF_SECTION_OPTION=VALUE
 ## example:
 ##  ARANGOCONF_LOG_LEVEL=debug
 ##   => update [log] section with "level = debug"
@@ -33,14 +33,14 @@ updateconf() {
     | grep -e '^arangoconf' \
     | while read -r var value; do
 
-        ## Extract section name and parameter name from var name.
+        ## Extract section name and option name from var name.
         # :: In POSIX sh, process substitution is undefined. In bash we would do:
-        # :: $ read -r section param < <(echo "$var" | sed -n 's/ARANGOCONF_\([^_]*\)_\(.*\)/\1 \2/p')
+        # :: $ read -r section option < <(echo "$var" | sed -n 's/ARANGOCONF_\([^_]*\)_\(.*\)/\1 \2/p')
         # :: so let's split it in 2 separate parsings
         section=$(echo "$var" | sed -n 's/arangoconf_\([^_]*\)_\(.*\)/\1/p')
-        param=$(echo "$var" | sed -n 's/arangoconf_\([^_]*\)_\(.*\)/\2/p')
-        param=$(echo "$param" | sed 's/_/-/') # env vars use '_' but param names use '-'
-        if [ "$section" = "" ] || [ "$param" = "" ]; then continue; fi # bypass invalid vars
+        option=$(echo "$var" | sed -n 's/arangoconf_\([^_]*\)_\(.*\)/\2/p')
+        option=$(echo "$option" | sed 's/_/-/') # env vars use '_' but option names use '-'
+        if [ "$section" = "" ] || [ "$option" = "" ]; then continue; fi # bypass invalid vars
 
         # :: array not available in POSIX sh - let's hope sections are never duplicate
         file="$(ls "$tmpconfdir"/[0-9][0-9]-"$section" 2>/dev/null || true)"
@@ -48,13 +48,13 @@ updateconf() {
         if [ ! -f "$file" ]; then # section (file) not yet existing
           file="$tmpconfdir"/99-"$section"
           echo "[$section]" >> "$file"
-          echo "$param = $value" >> "$file"
+          echo "$option = $value" >> "$file"
 
         else # section already existing
-          if grep -qe "^$param = " "$file"; then # parameter already existing - replace
-            sed -i 's/^'"$param"' = .*/'"$param"' = '"$value"'/g' "$file"
-          else # parameter not yet existing - just add
-            echo "$param = $value" >> "$file"
+          if grep -qe "^$option = " "$file"; then # option already existing - replace
+            sed -i 's/^'"$option"' = .*/'"$option"' = '"$value"'/g' "$file"
+          else # option not yet existing - just add
+            echo "$option = $value" >> "$file"
           fi
         fi
 


### PR DESCRIPTION
**new feature**:
you can override ArangoDB config with environment variables.
This to follow 12-factors principles: https://12factor.net/config

Here is the syntax:

```
env vars syntax:
 ARANGOCONF_SECTION_PARAMETER=VALUE
example:
 ARANGOCONF_LOG_LEVEL=debug
  => update [log] section with "level = debug"
```

**Reasons for doing this:**
* have all conf set by env vars, rather than a part in 'command' and a part in 'environment'.
* can lead to more systematic entrypoint code, where we don't manage ARANGO_ENCRYPTION_KEYFILE and ARANGO_STORAGE_ENGINE in a specific way (can be introduced later, and documented as var names would change).
* var names can be determined from official documentation.


All in all, I believe it's more logical / simple from a user point of view.
