### PR TITLE
Enable OpenSSL strict version to separate ArangoDB

### DIFF
--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -164,7 +164,7 @@ function findRequiredOpenSSL
   #  return 0
   #end
 
-  set -l v (fgrep OPENSSL_LINUX $f | awk '{print $2}' | tr -d '"' | tr -d "'")
+  set -l v (fgrep OPENSSL_LINUX VERSIONS | awk '{print $2}' | tr -d '"' | tr -d "'" | grep -o "[0-9]\.[0-9]\.[0-9]")
 
   if test "$v" = ""
     echo "$f: no OPENSSL_LINUX specified, using 1.1.0"

--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -164,7 +164,7 @@ function findRequiredOpenSSL
   #  return 0
   #end
 
-  set -l v (fgrep OPENSSL_LINUX VERSIONS | awk '{print $2}' | tr -d '"' | tr -d "'" | grep -o "[0-9]\.[0-9]\.[0-9]")
+  set -l v (fgrep OPENSSL_LINUX $f | awk '{print $2}' | tr -d '"' | tr -d "'" | grep -o "[0-9]\.[0-9]\.[0-9]")
 
   if test "$v" = ""
     echo "$f: no OPENSSL_LINUX specified, using 1.1.0"

--- a/helper.mac.fish
+++ b/helper.mac.fish
@@ -102,7 +102,7 @@ function findRequiredOpenSSL
   #  return 0
   #end
 
-  set -l v (fgrep OPENSSL_MACOS VERSIONS | awk '{print $2}' | tr -d '"' | tr -d "'" | grep -o "[0-9]\.[0-9]\.[0-9]")
+  set -l v (fgrep OPENSSL_MACOS $f | awk '{print $2}' | tr -d '"' | tr -d "'" | grep -o "[0-9]\.[0-9]\.[0-9]")
 
   if test "$v" = ""
     echo "$f: no OPENSSL_MACOS specified, using 1.0.2"

--- a/helper.mac.fish
+++ b/helper.mac.fish
@@ -102,7 +102,7 @@ function findRequiredOpenSSL
   #  return 0
   #end
 
-  set -l v (fgrep OPENSSL_MACOS $f | awk '{print $2}' | tr -d '"' | tr -d "'")
+  set -l v (fgrep OPENSSL_MACOS VERSIONS | awk '{print $2}' | tr -d '"' | tr -d "'" | grep -o "[0-9]\.[0-9]\.[0-9]")
 
   if test "$v" = ""
     echo "$f: no OPENSSL_MACOS specified, using 1.0.2"

--- a/helper.psm1
+++ b/helper.psm1
@@ -277,17 +277,17 @@ Function buildOpenSSL ($path, $version, $msvs, [string[]] $modes, [string[]] $ty
   }
   If ($global:ok)
   {
-    proc -process "git"  -argument "clone -b $OPENSSL_TAG https://github.com/openssl/openssl $env:TMP\OpenSSL\tmp" -logfile $false -priority "Normal"
+    proc -process "git"  -argument "clone -q -b $OPENSSL_TAG https://github.com/openssl/openssl $env:TMP\OpenSSL\tmp" -logfile $false -priority "Normal"
     Set-Location "$env:TMP\OpenSSL\tmp"
     If ($global:ok)
     {
-      proc -process "git" -argument "fetch --no-progress" -logfile $false -priority "Normal"
+      proc -process "git" -argument "fetch -q" -logfile $false -priority "Normal"
       If ($global:ok)
       {
-        proc -process "git" -argument "reset --no-progress --hard $OPENSSL_TAG"  -logfile $false -priority "Normal"
+        proc -process "git" -argument "reset -q --hard $OPENSSL_TAG"  -logfile $false -priority "Normal"
         If ($global:ok)
         {
-          proc -process "git" -argument "clean --no-progress -fdx"
+          proc -process "git" -argument "clean -q -fdx"
           ForEach($mode In $modes)
           {
             ForEach($type In $types)

--- a/helper.psm1
+++ b/helper.psm1
@@ -275,9 +275,9 @@ Function buildOpenSSL ($path, $version, $msvs, [string[]] $modes, [string[]] $ty
 
   proc -process "git"  -argument "clone -b $OPENSSL_TAG https://github.com/openssl/openssl $env:TMP\OpenSSL\tmp" -logfile $false -priority "Normal"
   Set-Location "$env:TMP\OpenSSL\tmp"
-  proc -process "git" -argument "fetch" -logfile $false -priority "Normal"
-  proc -process "git" -argument "reset --hard $OPENSSL_TAG"  -logfile $false -priority "Normal"
-  proc -process "git" -argument "clean -fdx"
+  proc -process "git" -argument "fetch --no-progress" -logfile $false -priority "Normal"
+  proc -process "git" -argument "reset --no-progress --hard $OPENSSL_TAG"  -logfile $false -priority "Normal"
+  proc -process "git" -argument "clean --no-progress -fdx"
 
   ForEach($mode In $modes)
   {

--- a/scripts/lib/Utils.psm1
+++ b/scripts/lib/Utils.psm1
@@ -115,10 +115,9 @@ Function createReport
 
 Function runTests
 {
-    If(Test-Path -PathType Container -Path $env:TMP)
+    If (Test-Path -PathType Container -Path $env:TMP)
     {
-        Remove-Item -Recurse -Force -Path $env:TMP
-        New-Item -ItemType Directory -Path $env:TMP
+        Remove-Item -Recurse -Force -Path $env:TMP -Exclude "$env:TMP\OpenSSL"
     }
     Else
     {
@@ -126,7 +125,7 @@ Function runTests
     }
     Push-Location $pwd
     Set-Location $global:ARANGODIR
-    ForEach($log in $(Get-ChildItem -Filter "*.log"))
+    ForEach ($log in $(Get-ChildItem -Filter "*.log"))
     {
         Remove-Item -Recurse -Force $log 
     }


### PR DESCRIPTION
Enable OpenSSL strict version to separate ArangoDB:

- devel: https://github.com/arangodb/arangodb/pull/10325
- 3.5: https://github.com/arangodb/arangodb/pull/10326
- 3.4: https://github.com/arangodb/arangodb/pull/10327

oskar PR: this

