### PR TITLE
remove storage engine selection from installers for 3.7

### DIFF
--- a/containers/arangodbDevel.docker/entrypoint.sh
+++ b/containers/arangodbDevel.docker/entrypoint.sh
@@ -42,21 +42,12 @@ if [ "$1" = 'arangod' ]; then
     # must work regardless under which user we run:
     cp /etc/arangodb3/arangod.conf /tmp/arangod.conf
 
+    ARANGO_STORAGE_ENGINE=rocksdb
     if [ ! -z "$ARANGO_ENCRYPTION_KEYFILE" ]; then
         echo "Using encrypted database"
         sed -i /tmp/arangod.conf -e "s;^.*encryption-keyfile.*;encryption-keyfile=$ARANGO_ENCRYPTION_KEYFILE;"
-        ARANGO_STORAGE_ENGINE=rocksdb
     fi
 
-    if [ "$ARANGO_STORAGE_ENGINE" == "rocksdb" ]; then
-        echo "choosing RocksDB storage engine"
-        sed -i /tmp/arangod.conf -e "s;storage-engine = auto;storage-engine = rocksdb;"
-    elif [ "$ARANGO_STORAGE_ENGINE" == "mmfiles" ]; then
-        echo "choosing MMFiles storage engine"
-        sed -i /tmp/arangod.conf -e "s;storage-engine = auto;storage-engine = mmfiles;"
-    else
-        echo "automatically choosing storage engine"
-    fi
     if [ ! -f /var/lib/arangodb3/SERVER ] && [ "$SKIP_DATABASE_INIT" != "1" ]; then
         if [ ! -z "$ARANGO_ROOT_PASSWORD_FILE" ]; then
             if [ -f "$ARANGO_ROOT_PASSWORD_FILE" ]; then

--- a/containers/arangodbDevelubi.docker/entrypoint.sh
+++ b/containers/arangodbDevelubi.docker/entrypoint.sh
@@ -42,21 +42,12 @@ if [ "$1" = 'arangod' ]; then
     # must work regardless under which user we run:
     cp /etc/arangodb3/arangod.conf /tmp/arangod.conf
 
+    ARANGO_STORAGE_ENGINE=rocksdb
     if [ ! -z "$ARANGO_ENCRYPTION_KEYFILE" ]; then
         echo "Using encrypted database"
         sed -i /tmp/arangod.conf -e "s;^.*encryption-keyfile.*;encryption-keyfile=$ARANGO_ENCRYPTION_KEYFILE;"
-        ARANGO_STORAGE_ENGINE=rocksdb
     fi
 
-    if [ "$ARANGO_STORAGE_ENGINE" == "rocksdb" ]; then
-        echo "choosing RocksDB storage engine"
-        sed -i /tmp/arangod.conf -e "s;storage-engine = auto;storage-engine = rocksdb;"
-    elif [ "$ARANGO_STORAGE_ENGINE" == "mmfiles" ]; then
-        echo "choosing MMFiles storage engine"
-        sed -i /tmp/arangod.conf -e "s;storage-engine = auto;storage-engine = mmfiles;"
-    else
-        echo "automatically choosing storage engine"
-    fi
     if [ ! -f /var/lib/arangodb3/SERVER ] && [ "$SKIP_DATABASE_INIT" != "1" ]; then
         if [ ! -z "$ARANGO_ROOT_PASSWORD_FILE" ]; then
             if [ -f "$ARANGO_ROOT_PASSWORD_FILE" ]; then

--- a/debian/default/common/config
+++ b/debian/default/common/config
@@ -29,7 +29,7 @@ fi
 #do the actual configure
 if test "$DO_CONFIGURE" = "yes"; then
     STATE=1
-    LASTSTATE=5
+    LASTSTATE=4
     while test "$STATE" -ne 0 -a \
                "$STATE" -le "$LASTSTATE" ; do
 
@@ -56,10 +56,6 @@ if test "$DO_CONFIGURE" = "yes"; then
                 db_input high @EDITION@/upgrade || true
             ;;
             4)
-                db_input high @EDITION@/storage_engine || true
-                db_go
-            ;;
-            5)
                 db_get @EDITION@/upgrade
                 if [ "$RET" = "true" ]; then
                     db_input high @EDITION@/backup || true

--- a/debian/default/common/postinst
+++ b/debian/default/common/postinst
@@ -10,8 +10,6 @@ ARANGODB="/usr/sbin/arangod"
 . /usr/share/debconf/confmodule
 . /usr/share/arangodb3/arangodb-helper
 
-db_get @EDITION@/storage_engine
-STORAGE_ENGINE=$RET
 export GLIBCXX_FORCE_NEW=1
 
 if test -d /var/lib/arangodb3 -a ! -f /usr/sbin/arangod; then
@@ -19,9 +17,6 @@ if test -d /var/lib/arangodb3 -a ! -f /usr/sbin/arangod; then
 else
     NEW_INSTALL_EXISTING_DIR=false
 fi
-
-# fill in correct storage engine into arangod.conf
-sed -i /etc/arangodb3/arangod.conf -e "s;storage-engine = auto;storage-engine = $STORAGE_ENGINE;"
 
 if [ -d "/run/systemd/system" ] ; then
     if deb-systemd-invoke is-active arangodb3.service 2>&1 >/dev/null ; then

--- a/debian/default/common/templates
+++ b/debian/default/common/templates
@@ -32,14 +32,3 @@ Type: error
 Description: Password input error
  The two passwords you entered were not the same. Please try again.
 
-Template: @EDITION@/storage_engine
-Type: select
-Choices: auto, rocksdb, mmfiles
-Default: auto
-Description: Database storage engine
- Choose which storage engine you want to use.
- Please note that you can't switch storage engines of existing installations,
- a dump and restore is required therefore.
- 
- 'auto' will pick the existing one or default to rocksdb since ArangoDB 3.4, and to mmfiles before.
-


### PR DESCRIPTION
Oskar companion PR for https://github.com/arangodb/arangodb/pull/11047
The intention is to remove the storage engine selection from the installers built with Oskar.