### PR TITLE
Avoid blacklisted tests with additional index

### DIFF
--- a/scripts/lib/Utils.psm1
+++ b/scripts/lib/Utils.psm1
@@ -212,7 +212,9 @@ Function launchTest($which) {
 Function registerTest($testname, $index, $bucket, $filter, $moreParams, $cluster, $weight, $sniff, [switch]$vst, [switch]$http2)
 {
     Write-Host "$global:ARANGODIR\UnitTests\OskarTestSuitesBlackList"
-    If(-Not(Select-String -Path "$global:ARANGODIR\UnitTests\OskarTestSuitesBlackList" -pattern $testname))
+    $checkname = If ($index) { $testname + "_$index" } Else { $testname }
+    
+    If(-Not(Select-String -Path "$global:ARANGODIR\UnitTests\OskarTestSuitesBlackList" -pattern $checkname))
     {
         $testWeight = 1
         $testparams = ""
@@ -220,7 +222,7 @@ Function registerTest($testname, $index, $bucket, $filter, $moreParams, $cluster
 
         $output = $testname.replace("*", "all")
         If ($index) {
-          $output = $output+"$index"
+          $output = $output+"_$index"
         }
         If ($filter) {
            $testparams = $testparams+" --test $filter"

--- a/scripts/lib/Utils.psm1
+++ b/scripts/lib/Utils.psm1
@@ -214,7 +214,7 @@ Function registerTest($testname, $index, $bucket, $filter, $moreParams, $cluster
     Write-Host "$global:ARANGODIR\UnitTests\OskarTestSuitesBlackList"
     $checkname = If ($index) { $testname + "_$index" } Else { $testname }
     
-    If(-Not(Select-String -Path "$global:ARANGODIR\UnitTests\OskarTestSuitesBlackList" -pattern $checkname))
+    If(-Not(Select-String -Path "$global:ARANGODIR\UnitTests\OskarTestSuitesBlackList" -pattern "^$checkname$"))
     {
         $testWeight = 1
         $testparams = ""

--- a/scripts/lib/Utils.psm1
+++ b/scripts/lib/Utils.psm1
@@ -214,7 +214,7 @@ Function registerTest($testname, $index, $bucket, $filter, $moreParams, $cluster
     Write-Host "$global:ARANGODIR\UnitTests\OskarTestSuitesBlackList"
     $checkname = If ($index) { $testname + "_$index" } Else { $testname }
     
-    If(-Not(Select-String -Path "$global:ARANGODIR\UnitTests\OskarTestSuitesBlackList" -pattern "^$checkname$"))
+    If(-Not(Select-String -Path "$global:ARANGODIR\UnitTests\OskarTestSuitesBlackList" -pattern "^$checkname$" | select line))
     {
         $testWeight = 1
         $testparams = ""
@@ -289,7 +289,7 @@ Function registerTest($testname, $index, $bucket, $filter, $moreParams, $cluster
     }
     Else
     {
-        Write-Host "Test suite $testname skipped by UnitTests/OskarTestSuitesBlackList"
+        Write-Host "Test suite $checkname skipped by UnitTests/OskarTestSuitesBlackList"
     }
     comm
 }

--- a/scripts/lib/tests.fish
+++ b/scripts/lib/tests.fish
@@ -57,8 +57,8 @@ function runAnyTest
 
   if test $VERBOSEOSKAR = On ; echo "$launchCount: Launching $l0" ; end
 
-  if grep $t UnitTests/OskarTestSuitesBlackList
-    echo Test suite $t skipped by UnitTests/OskarTestSuitesBlackList
+  if grep -e "\b$t\b" -e "\b$l0\b" UnitTests/OskarTestSuitesBlackList
+    echo Test suite $l0 skipped by UnitTests/OskarTestSuitesBlackList
   else
     set -l arguments \'"$t"\' \
       (not test -z $ASAN; and test $ASAN = "On"; and echo "--isAsan true") \


### PR DESCRIPTION
The following blacklisted suites should be avoided:

3.3, 3.4, 3.5:
shell_client_vst
shell_client_http2
shell_client_aql_vst
shell_client_aql_http2

3.6:
shell_client_http2
shell_client_aql_http2

Additional PRs:
- 3.3: https://github.com/arangodb/arangodb/pull/11129
- 3.4: https://github.com/arangodb/arangodb/pull/11128
- 3.5: https://github.com/arangodb/arangodb/pull/11130
- 3.6: https://github.com/arangodb/arangodb/pull/11131
- devel: https://github.com/arangodb/arangodb/pull/11132