### PR TITLE
enable core analysis

### DIFF
--- a/scripts/lib/tests.fish
+++ b/scripts/lib/tests.fish
@@ -70,6 +70,7 @@ function runAnyTest
       --writeXmlReport false \
       --skipGrey "$SKIPGREY" \
       --onlyGrey "$ONLYGREY" \
+      --coreCheck true \
       $argv
 
     echo (pwd) "-" scripts/unittest $arguments


### PR DESCRIPTION
coredump reports outdo 1G. its ridiculus to download that without insight. 
This PR enables coredump analysis. 

http://jenkins01.arangodb.biz:8080/view/PR/job/arangodb-matrix-pr/8660/