### PR TITLE
Turn off cache for release builds

### DIFF
--- a/jenkins/releaseCommunityDocker.fish
+++ b/jenkins/releaseCommunityDocker.fish
@@ -10,6 +10,7 @@ cleanPrepareLockUpdateClear
 and cleanWorkspace
 and switchBranches "$RELEASE_TAG" "$RELEASE_TAG" true
 and showRepository
+and ccacheOff
 and makeDockerCommunityRelease
 
 set -l s $status

--- a/jenkins/releaseCommunityPackages.fish
+++ b/jenkins/releaseCommunityPackages.fish
@@ -9,6 +9,7 @@ end
 cleanPrepareLockUpdateClear
 and cleanWorkspace
 and switchBranches "$RELEASE_TAG" "$RELEASE_TAG" true
+and ccacheOff
 and makeCommunityRelease
 
 set -l s $status

--- a/jenkins/releaseCommunityPackages.ps1
+++ b/jenkins/releaseCommunityPackages.ps1
@@ -4,6 +4,7 @@ Copy-Item -Force "$env:WORKSPACE\jenkins\helper\prepareOskar.ps1" $pwd
 switchBranches $env:RELEASE_TAG $env:RELEASE_TAG
 If ($global:ok) 
 {
+    clcacheOff
     makeCommunityRelease
 }
 $s = $global:ok

--- a/jenkins/releaseEnterpriseDocker.fish
+++ b/jenkins/releaseEnterpriseDocker.fish
@@ -10,6 +10,7 @@ cleanPrepareLockUpdateClear
 and cleanWorkspace
 and switchBranches "$RELEASE_TAG" "$RELEASE_TAG" true
 and showRepository
+and ccacheOff
 and makeDockerEnterpriseRelease
 
 set -l s $status

--- a/jenkins/releaseEnterpriseDockerUbi.fish
+++ b/jenkins/releaseEnterpriseDockerUbi.fish
@@ -11,6 +11,7 @@ and cleanWorkspace
 and switchBranches "$RELEASE_TAG" "$RELEASE_TAG" true
 and ubiDockerImage
 and showRepository
+and ccacheOff
 and makeDockerEnterpriseRelease
 
 set -l s $status

--- a/jenkins/releaseEnterprisePackages.fish
+++ b/jenkins/releaseEnterprisePackages.fish
@@ -9,6 +9,7 @@ end
 cleanPrepareLockUpdateClear
 and cleanWorkspace
 and switchBranches "$RELEASE_TAG" "$RELEASE_TAG" true
+and ccacheOff
 and makeEnterpriseRelease
 
 set -l s $status

--- a/jenkins/releaseEnterprisePackages.ps1
+++ b/jenkins/releaseEnterprisePackages.ps1
@@ -4,6 +4,7 @@ Copy-Item -Force "$env:WORKSPACE\jenkins\helper\prepareOskar.ps1" $pwd
 switchBranches $env:RELEASE_TAG $env:RELEASE_TAG
 If ($global:ok) 
 {
+    clcacheOff
     makeEnterpriseRelease
 }
 $s = $global:ok

--- a/jenkins/releasePackages.fish
+++ b/jenkins/releasePackages.fish
@@ -9,6 +9,7 @@ end
 cleanPrepareLockUpdateClear
 and cleanWorkspace
 and switchBranches "$RELEASE_TAG" "$RELEASE_TAG" true
+and ccacheOff
 and makeRelease
 
 set -l s $status


### PR DESCRIPTION
Occasionally we realized that release jobs for packages do use cache (sccache for Linux and macOS and clcache for Windows). That should not happen!