### PR TITLE
Remove npm from images and use NodeJS (12) from Alpine 3.11

### DIFF
--- a/containers/arangodb34.docker/Dockerfile
+++ b/containers/arangodb34.docker/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.10
 MAINTAINER Max Neunhoeffer <max@arangodb.com>
 
-RUN apk add --no-cache pwgen nodejs npm binutils numactl numactl-tools
-RUN npm install -g foxx-cli
+RUN apk add --no-cache pwgen binutils numactl numactl-tools
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.11/main/ nodejs
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.11/main/ npm && npm install -g foxx-cli && apk del npm
 
 ADD install.tar.gz /
 COPY setup.sh /setup.sh

--- a/containers/arangodb35.docker/Dockerfile
+++ b/containers/arangodb35.docker/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.10
 MAINTAINER Max Neunhoeffer <max@arangodb.com>
 
-RUN apk add --no-cache pwgen nodejs npm binutils numactl numactl-tools
-RUN npm install -g foxx-cli
+RUN apk add --no-cache pwgen binutils numactl numactl-tools
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.11/main/ nodejs
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.11/main/ npm && npm install -g foxx-cli && apk del npm
 
 ADD install.tar.gz /
 COPY setup.sh /setup.sh

--- a/containers/arangodb36.docker/Dockerfile
+++ b/containers/arangodb36.docker/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.10
 MAINTAINER Max Neunhoeffer <max@arangodb.com>
 
-RUN apk add --no-cache pwgen nodejs npm binutils numactl numactl-tools
-RUN npm install -g foxx-cli
+RUN apk add --no-cache pwgen binutils numactl numactl-tools
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.11/main/ nodejs
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.11/main/ npm && npm install -g foxx-cli && apk del npm
 
 ADD install.tar.gz /
 COPY setup.sh /setup.sh

--- a/containers/arangodb37.docker/Dockerfile
+++ b/containers/arangodb37.docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.11
 MAINTAINER Max Neunhoeffer <max@arangodb.com>
 
-RUN apk add --no-cache pwgen nodejs npm binutils numactl numactl-tools
-RUN npm install -g foxx-cli
+RUN apk add --no-cache pwgen nodejs binutils numactl numactl-tools
+RUN apk add --no-cache npm && npm install -g foxx-cli && apk del npm
 
 ADD install.tar.gz /
 COPY setup.sh /setup.sh

--- a/containers/arangodbDevel.docker/Dockerfile
+++ b/containers/arangodbDevel.docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.11
 MAINTAINER Max Neunhoeffer <max@arangodb.com>
 
-RUN apk add --no-cache pwgen nodejs npm binutils numactl numactl-tools
-RUN npm install -g foxx-cli
+RUN apk add --no-cache pwgen nodejs binutils numactl numactl-tools
+RUN apk add --no-cache npm && npm install -g foxx-cli && apk del npm
 
 ADD install.tar.gz /
 COPY setup.sh /setup.sh


### PR DESCRIPTION
Use foxx-cli 2.0.0 (requires NodeJS 12+) just built by Alan Plum (https://www.npmjs.com/package/foxx-cli/v/2.0.0):
3.4:
 - docker: http://jenkins01.arangodb.biz:8080/view/Docker/job/arangodb-ANY-docker-packages/405/
 - drivers: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/7/
3.5:
 - docker: http://jenkins01.arangodb.biz:8080/view/Docker/job/arangodb-ANY-docker-packages/403/
 - drivers: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/4/
3.6:
 - docker: http://jenkins01.arangodb.biz:8080/view/Docker/job/arangodb-ANY-docker-packages/402/
 - drivers: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/3/
3.7:
 - docker: http://jenkins01.arangodb.biz:8080/view/Docker/job/arangodb-ANY-docker-packages/401/
 - drivers: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/6/
devel:
 - docker: http://jenkins01.arangodb.biz:8080/view/Docker/job/arangodb-ANY-docker-packages/404/
 - drivers: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/5/