### PR TITLE
Fix DEB dbg installer conflicts

### DIFF
--- a/debian/3.2/community/control
+++ b/debian/3.2/community/control
@@ -36,7 +36,7 @@ Package: arangodb3-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
-Pre-Depends:$
+Pre-Depends:
     arangodb3 (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.2/community/control
+++ b/debian/3.2/community/control
@@ -36,7 +36,7 @@ Package: arangodb3-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
-Depends:
+Pre-Depends:$
     arangodb3 (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.2/enterprise/control
+++ b/debian/3.2/enterprise/control
@@ -36,7 +36,7 @@ Package: arangodb3e-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
-Pre-Depends:$
+Pre-Depends:
     arangodb3e (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.2/enterprise/control
+++ b/debian/3.2/enterprise/control
@@ -36,7 +36,7 @@ Package: arangodb3e-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
-Depends:
+Pre-Depends:$
     arangodb3e (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.3/community/control
+++ b/debian/3.3/community/control
@@ -36,7 +36,7 @@ Package: arangodb3-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
-Pre-Depends:$
+Pre-Depends:
     arangodb3 (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.3/community/control
+++ b/debian/3.3/community/control
@@ -36,7 +36,7 @@ Package: arangodb3-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
-Depends:
+Pre-Depends:$
     arangodb3 (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.3/enterprise/control
+++ b/debian/3.3/enterprise/control
@@ -36,7 +36,7 @@ Package: arangodb3e-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
-Pre-Depends:$
+Pre-Depends:
     arangodb3e (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.3/enterprise/control
+++ b/debian/3.3/enterprise/control
@@ -36,7 +36,7 @@ Package: arangodb3e-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
-Depends:
+Pre-Depends:$
     arangodb3e (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.4/community/control
+++ b/debian/3.4/community/control
@@ -40,10 +40,10 @@ Conflicts:
     arangodb3e,
     arangodb3e-client,
     arangodb3e-dbg,
-    arangodb3 (< ${binary:Version}),
-    arangodb3 (> ${binary:Version}),
-    arangodb3-client (< ${binary:Version}),
-    arangodb3-client (> ${binary:Version})
+    arangodb3 (<< ${binary:Version}),
+    arangodb3 (>> ${binary:Version}),
+    arangodb3-client (<< ${binary:Version}),
+    arangodb3-client (>> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.4/community/control
+++ b/debian/3.4/community/control
@@ -43,7 +43,7 @@ Conflicts:
     arangodb3 (< ${binary:Version}),
     arangodb3 (> ${binary:Version})
 Depends:
-    arangodb3 (= ${binary:Version}),
+    arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb
  A distributed free and open-source database with a flexible data model for documents,

--- a/debian/3.4/community/control
+++ b/debian/3.4/community/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3 (>> ${binary:Version}),
     arangodb3-client (<< ${binary:Version}),
     arangodb3-client (>> ${binary:Version})
-Pre-Depends:$
+Pre-Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.4/community/control
+++ b/debian/3.4/community/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3 (>> ${binary:Version}),
     arangodb3-client (<< ${binary:Version}),
     arangodb3-client (>> ${binary:Version})
-Depends:
+Pre-Depends:$
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.4/community/control
+++ b/debian/3.4/community/control
@@ -36,6 +36,12 @@ Package: arangodb3-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
+Conflicts:
+    arangodb3e,
+    arangodb3e-client,
+    arangodb3e-dbg,
+    arangodb3 (< ${binary:Version}),
+    arangodb3 (> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.4/community/control
+++ b/debian/3.4/community/control
@@ -41,7 +41,9 @@ Conflicts:
     arangodb3e-client,
     arangodb3e-dbg,
     arangodb3 (< ${binary:Version}),
-    arangodb3 (> ${binary:Version})
+    arangodb3 (> ${binary:Version}),
+    arangodb3-client (< ${binary:Version}),
+    arangodb3-client (> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.4/enterprise/control
+++ b/debian/3.4/enterprise/control
@@ -36,6 +36,12 @@ Package: arangodb3e-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
+Conflicts:
+    arangodb3,
+    arangodb3-client,
+    arangodb3-dbg,
+    arangodb3e (< ${binary:Version}),
+    arangodb3e (> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.4/enterprise/control
+++ b/debian/3.4/enterprise/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3e (>> ${binary:Version}),
     arangodb3e-client (<< ${binary:Version}),
     arangodb3e-client (>> ${binary:Version})
-Depends:
+Pre-Depends:$
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.4/enterprise/control
+++ b/debian/3.4/enterprise/control
@@ -41,7 +41,9 @@ Conflicts:
     arangodb3-client,
     arangodb3-dbg,
     arangodb3e (< ${binary:Version}),
-    arangodb3e (> ${binary:Version})
+    arangodb3e (> ${binary:Version}),
+    arangodb3e-client (< ${binary:Version}),
+    arangodb3e-client (> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.4/enterprise/control
+++ b/debian/3.4/enterprise/control
@@ -43,7 +43,7 @@ Conflicts:
     arangodb3e (< ${binary:Version}),
     arangodb3e (> ${binary:Version})
 Depends:
-    arangodb3e (= ${binary:Version}),
+    arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb
  A distributed free and open-source database with a flexible data model for documents,

--- a/debian/3.4/enterprise/control
+++ b/debian/3.4/enterprise/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3e (>> ${binary:Version}),
     arangodb3e-client (<< ${binary:Version}),
     arangodb3e-client (>> ${binary:Version})
-Pre-Depends:$
+Pre-Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.4/enterprise/control
+++ b/debian/3.4/enterprise/control
@@ -40,10 +40,10 @@ Conflicts:
     arangodb3,
     arangodb3-client,
     arangodb3-dbg,
-    arangodb3e (< ${binary:Version}),
-    arangodb3e (> ${binary:Version}),
-    arangodb3e-client (< ${binary:Version}),
-    arangodb3e-client (> ${binary:Version})
+    arangodb3e (<< ${binary:Version}),
+    arangodb3e (>> ${binary:Version}),
+    arangodb3e-client (<< ${binary:Version}),
+    arangodb3e-client (>> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.5/community/control
+++ b/debian/3.5/community/control
@@ -40,10 +40,10 @@ Conflicts:
     arangodb3e,
     arangodb3e-client,
     arangodb3e-dbg,
-    arangodb3 (< ${binary:Version}),
-    arangodb3 (> ${binary:Version}),
-    arangodb3-client (< ${binary:Version}),
-    arangodb3-client (> ${binary:Version})
+    arangodb3 (<< ${binary:Version}),
+    arangodb3 (>> ${binary:Version}),
+    arangodb3-client (<< ${binary:Version}),
+    arangodb3-client (>> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.5/community/control
+++ b/debian/3.5/community/control
@@ -43,7 +43,7 @@ Conflicts:
     arangodb3 (< ${binary:Version}),
     arangodb3 (> ${binary:Version})
 Depends:
-    arangodb3 (= ${binary:Version}),
+    arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb
  A distributed free and open-source database with a flexible data model for documents,

--- a/debian/3.5/community/control
+++ b/debian/3.5/community/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3 (>> ${binary:Version}),
     arangodb3-client (<< ${binary:Version}),
     arangodb3-client (>> ${binary:Version})
-Pre-Depends:$
+Pre-Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.5/community/control
+++ b/debian/3.5/community/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3 (>> ${binary:Version}),
     arangodb3-client (<< ${binary:Version}),
     arangodb3-client (>> ${binary:Version})
-Depends:
+Pre-Depends:$
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.5/community/control
+++ b/debian/3.5/community/control
@@ -36,6 +36,12 @@ Package: arangodb3-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
+Conflicts:
+    arangodb3e,
+    arangodb3e-client,
+    arangodb3e-dbg,
+    arangodb3 (< ${binary:Version}),
+    arangodb3 (> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.5/community/control
+++ b/debian/3.5/community/control
@@ -41,7 +41,9 @@ Conflicts:
     arangodb3e-client,
     arangodb3e-dbg,
     arangodb3 (< ${binary:Version}),
-    arangodb3 (> ${binary:Version})
+    arangodb3 (> ${binary:Version}),
+    arangodb3-client (< ${binary:Version}),
+    arangodb3-client (> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.5/enterprise/control
+++ b/debian/3.5/enterprise/control
@@ -36,6 +36,12 @@ Package: arangodb3e-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
+Conflicts:
+    arangodb3,
+    arangodb3-client,
+    arangodb3-dbg,
+    arangodb3e (< ${binary:Version}),
+    arangodb3e (> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.5/enterprise/control
+++ b/debian/3.5/enterprise/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3e (>> ${binary:Version}),
     arangodb3e-client (<< ${binary:Version}),
     arangodb3e-client (>> ${binary:Version})
-Depends:
+Pre-Depends:$
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.5/enterprise/control
+++ b/debian/3.5/enterprise/control
@@ -41,7 +41,9 @@ Conflicts:
     arangodb3-client,
     arangodb3-dbg,
     arangodb3e (< ${binary:Version}),
-    arangodb3e (> ${binary:Version})
+    arangodb3e (> ${binary:Version}),
+    arangodb3e-client (< ${binary:Version}),
+    arangodb3e-client (> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.5/enterprise/control
+++ b/debian/3.5/enterprise/control
@@ -43,7 +43,7 @@ Conflicts:
     arangodb3e (< ${binary:Version}),
     arangodb3e (> ${binary:Version})
 Depends:
-    arangodb3e (= ${binary:Version}),
+    arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb
  A distributed free and open-source database with a flexible data model for documents,

--- a/debian/3.5/enterprise/control
+++ b/debian/3.5/enterprise/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3e (>> ${binary:Version}),
     arangodb3e-client (<< ${binary:Version}),
     arangodb3e-client (>> ${binary:Version})
-Pre-Depends:$
+Pre-Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.5/enterprise/control
+++ b/debian/3.5/enterprise/control
@@ -40,10 +40,10 @@ Conflicts:
     arangodb3,
     arangodb3-client,
     arangodb3-dbg,
-    arangodb3e (< ${binary:Version}),
-    arangodb3e (> ${binary:Version}),
-    arangodb3e-client (< ${binary:Version}),
-    arangodb3e-client (> ${binary:Version})
+    arangodb3e (<< ${binary:Version}),
+    arangodb3e (>> ${binary:Version}),
+    arangodb3e-client (<< ${binary:Version}),
+    arangodb3e-client (>> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.6/community/control
+++ b/debian/3.6/community/control
@@ -40,10 +40,10 @@ Conflicts:
     arangodb3e,
     arangodb3e-client,
     arangodb3e-dbg,
-    arangodb3 (< ${binary:Version}),
-    arangodb3 (> ${binary:Version}),
-    arangodb3-client (< ${binary:Version}),
-    arangodb3-client (> ${binary:Version})
+    arangodb3 (<< ${binary:Version}),
+    arangodb3 (>> ${binary:Version}),
+    arangodb3-client (<< ${binary:Version}),
+    arangodb3-client (>> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.6/community/control
+++ b/debian/3.6/community/control
@@ -43,7 +43,7 @@ Conflicts:
     arangodb3 (< ${binary:Version}),
     arangodb3 (> ${binary:Version})
 Depends:
-    arangodb3 (= ${binary:Version}),
+    arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb
  A distributed free and open-source database with a flexible data model for documents,

--- a/debian/3.6/community/control
+++ b/debian/3.6/community/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3 (>> ${binary:Version}),
     arangodb3-client (<< ${binary:Version}),
     arangodb3-client (>> ${binary:Version})
-Pre-Depends:$
+Pre-Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.6/community/control
+++ b/debian/3.6/community/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3 (>> ${binary:Version}),
     arangodb3-client (<< ${binary:Version}),
     arangodb3-client (>> ${binary:Version})
-Depends:
+Pre-Depends:$
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.6/community/control
+++ b/debian/3.6/community/control
@@ -36,6 +36,12 @@ Package: arangodb3-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
+Conflicts:
+    arangodb3e,
+    arangodb3e-client,
+    arangodb3e-dbg,
+    arangodb3 (< ${binary:Version}),
+    arangodb3 (> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.6/community/control
+++ b/debian/3.6/community/control
@@ -41,7 +41,9 @@ Conflicts:
     arangodb3e-client,
     arangodb3e-dbg,
     arangodb3 (< ${binary:Version}),
-    arangodb3 (> ${binary:Version})
+    arangodb3 (> ${binary:Version}),
+    arangodb3-client (< ${binary:Version}),
+    arangodb3-client (> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.6/enterprise/control
+++ b/debian/3.6/enterprise/control
@@ -36,6 +36,12 @@ Package: arangodb3e-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
+Conflicts:
+    arangodb3,
+    arangodb3-client,
+    arangodb3-dbg,
+    arangodb3e (< ${binary:Version}),
+    arangodb3e (> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.6/enterprise/control
+++ b/debian/3.6/enterprise/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3e (>> ${binary:Version}),
     arangodb3e-client (<< ${binary:Version}),
     arangodb3e-client (>> ${binary:Version})
-Depends:
+Pre-Depends:$
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.6/enterprise/control
+++ b/debian/3.6/enterprise/control
@@ -41,7 +41,9 @@ Conflicts:
     arangodb3-client,
     arangodb3-dbg,
     arangodb3e (< ${binary:Version}),
-    arangodb3e (> ${binary:Version})
+    arangodb3e (> ${binary:Version}),
+    arangodb3e-client (< ${binary:Version}),
+    arangodb3e-client (> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.6/enterprise/control
+++ b/debian/3.6/enterprise/control
@@ -43,7 +43,7 @@ Conflicts:
     arangodb3e (< ${binary:Version}),
     arangodb3e (> ${binary:Version})
 Depends:
-    arangodb3e (= ${binary:Version}),
+    arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb
  A distributed free and open-source database with a flexible data model for documents,

--- a/debian/3.6/enterprise/control
+++ b/debian/3.6/enterprise/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3e (>> ${binary:Version}),
     arangodb3e-client (<< ${binary:Version}),
     arangodb3e-client (>> ${binary:Version})
-Pre-Depends:$
+Pre-Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.6/enterprise/control
+++ b/debian/3.6/enterprise/control
@@ -40,10 +40,10 @@ Conflicts:
     arangodb3,
     arangodb3-client,
     arangodb3-dbg,
-    arangodb3e (< ${binary:Version}),
-    arangodb3e (> ${binary:Version}),
-    arangodb3e-client (< ${binary:Version}),
-    arangodb3e-client (> ${binary:Version})
+    arangodb3e (<< ${binary:Version}),
+    arangodb3e (>> ${binary:Version}),
+    arangodb3e-client (<< ${binary:Version}),
+    arangodb3e-client (>> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.7/community/control
+++ b/debian/3.7/community/control
@@ -40,10 +40,10 @@ Conflicts:
     arangodb3e,
     arangodb3e-client,
     arangodb3e-dbg,
-    arangodb3 (< ${binary:Version}),
-    arangodb3 (> ${binary:Version}),
-    arangodb3-client (< ${binary:Version}),
-    arangodb3-client (> ${binary:Version})
+    arangodb3 (<< ${binary:Version}),
+    arangodb3 (>> ${binary:Version}),
+    arangodb3-client (<< ${binary:Version}),
+    arangodb3-client (>> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.7/community/control
+++ b/debian/3.7/community/control
@@ -43,7 +43,7 @@ Conflicts:
     arangodb3 (< ${binary:Version}),
     arangodb3 (> ${binary:Version})
 Depends:
-    arangodb3 (= ${binary:Version}),
+    arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb
  A distributed free and open-source database with a flexible data model for documents,

--- a/debian/3.7/community/control
+++ b/debian/3.7/community/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3 (>> ${binary:Version}),
     arangodb3-client (<< ${binary:Version}),
     arangodb3-client (>> ${binary:Version})
-Pre-Depends:$
+Pre-Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.7/community/control
+++ b/debian/3.7/community/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3 (>> ${binary:Version}),
     arangodb3-client (<< ${binary:Version}),
     arangodb3-client (>> ${binary:Version})
-Depends:
+Pre-Depends:$
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.7/community/control
+++ b/debian/3.7/community/control
@@ -36,6 +36,12 @@ Package: arangodb3-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
+Conflicts:
+    arangodb3e,
+    arangodb3e-client,
+    arangodb3e-dbg,
+    arangodb3 (< ${binary:Version}),
+    arangodb3 (> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.7/community/control
+++ b/debian/3.7/community/control
@@ -41,7 +41,9 @@ Conflicts:
     arangodb3e-client,
     arangodb3e-dbg,
     arangodb3 (< ${binary:Version}),
-    arangodb3 (> ${binary:Version})
+    arangodb3 (> ${binary:Version}),
+    arangodb3-client (< ${binary:Version}),
+    arangodb3-client (> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.7/enterprise/control
+++ b/debian/3.7/enterprise/control
@@ -36,6 +36,12 @@ Package: arangodb3e-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
+Conflicts:
+    arangodb3,
+    arangodb3-client,
+    arangodb3-dbg,
+    arangodb3e (< ${binary:Version}),
+    arangodb3e (> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.7/enterprise/control
+++ b/debian/3.7/enterprise/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3e (>> ${binary:Version}),
     arangodb3e-client (<< ${binary:Version}),
     arangodb3e-client (>> ${binary:Version})
-Depends:
+Pre-Depends:$
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.7/enterprise/control
+++ b/debian/3.7/enterprise/control
@@ -41,7 +41,9 @@ Conflicts:
     arangodb3-client,
     arangodb3-dbg,
     arangodb3e (< ${binary:Version}),
-    arangodb3e (> ${binary:Version})
+    arangodb3e (> ${binary:Version}),
+    arangodb3e-client (< ${binary:Version}),
+    arangodb3e-client (> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/3.7/enterprise/control
+++ b/debian/3.7/enterprise/control
@@ -43,7 +43,7 @@ Conflicts:
     arangodb3e (< ${binary:Version}),
     arangodb3e (> ${binary:Version})
 Depends:
-    arangodb3e (= ${binary:Version}),
+    arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb
  A distributed free and open-source database with a flexible data model for documents,

--- a/debian/3.7/enterprise/control
+++ b/debian/3.7/enterprise/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3e (>> ${binary:Version}),
     arangodb3e-client (<< ${binary:Version}),
     arangodb3e-client (>> ${binary:Version})
-Pre-Depends:$
+Pre-Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/3.7/enterprise/control
+++ b/debian/3.7/enterprise/control
@@ -40,10 +40,10 @@ Conflicts:
     arangodb3,
     arangodb3-client,
     arangodb3-dbg,
-    arangodb3e (< ${binary:Version}),
-    arangodb3e (> ${binary:Version}),
-    arangodb3e-client (< ${binary:Version}),
-    arangodb3e-client (> ${binary:Version})
+    arangodb3e (<< ${binary:Version}),
+    arangodb3e (>> ${binary:Version}),
+    arangodb3e-client (<< ${binary:Version}),
+    arangodb3e-client (>> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/default/community/control
+++ b/debian/default/community/control
@@ -40,10 +40,10 @@ Conflicts:
     arangodb3e,
     arangodb3e-client,
     arangodb3e-dbg,
-    arangodb3 (< ${binary:Version}),
-    arangodb3 (> ${binary:Version}),
-    arangodb3-client (< ${binary:Version}),
-    arangodb3-client (> ${binary:Version})
+    arangodb3 (<< ${binary:Version}),
+    arangodb3 (>> ${binary:Version}),
+    arangodb3-client (<< ${binary:Version}),
+    arangodb3-client (>> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/default/community/control
+++ b/debian/default/community/control
@@ -43,7 +43,7 @@ Conflicts:
     arangodb3 (< ${binary:Version}),
     arangodb3 (> ${binary:Version})
 Depends:
-    arangodb3 (= ${binary:Version}),
+    arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb
  A distributed free and open-source database with a flexible data model for documents,

--- a/debian/default/community/control
+++ b/debian/default/community/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3 (>> ${binary:Version}),
     arangodb3-client (<< ${binary:Version}),
     arangodb3-client (>> ${binary:Version})
-Pre-Depends:$
+Pre-Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/default/community/control
+++ b/debian/default/community/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3 (>> ${binary:Version}),
     arangodb3-client (<< ${binary:Version}),
     arangodb3-client (>> ${binary:Version})
-Depends:
+Pre-Depends:$
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/default/community/control
+++ b/debian/default/community/control
@@ -36,6 +36,12 @@ Package: arangodb3-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
+Conflicts:
+    arangodb3e,
+    arangodb3e-client,
+    arangodb3e-dbg,
+    arangodb3 (< ${binary:Version}),
+    arangodb3 (> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/default/community/control
+++ b/debian/default/community/control
@@ -41,7 +41,9 @@ Conflicts:
     arangodb3e-client,
     arangodb3e-dbg,
     arangodb3 (< ${binary:Version}),
-    arangodb3 (> ${binary:Version})
+    arangodb3 (> ${binary:Version}),
+    arangodb3-client (< ${binary:Version}),
+    arangodb3-client (> ${binary:Version})
 Depends:
     arangodb3 (= ${binary:Version}) | arangodb3-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/default/enterprise/control
+++ b/debian/default/enterprise/control
@@ -36,6 +36,12 @@ Package: arangodb3e-dbg
 Architecture: amd64
 Section: debug
 Priority: extra
+Conflicts:
+    arangodb3,
+    arangodb3-client,
+    arangodb3-dbg,
+    arangodb3e (< ${binary:Version}),
+    arangodb3e (> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/default/enterprise/control
+++ b/debian/default/enterprise/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3e (>> ${binary:Version}),
     arangodb3e-client (<< ${binary:Version}),
     arangodb3e-client (>> ${binary:Version})
-Depends:
+Pre-Depends:$
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/default/enterprise/control
+++ b/debian/default/enterprise/control
@@ -41,7 +41,9 @@ Conflicts:
     arangodb3-client,
     arangodb3-dbg,
     arangodb3e (< ${binary:Version}),
-    arangodb3e (> ${binary:Version})
+    arangodb3e (> ${binary:Version}),
+    arangodb3e-client (< ${binary:Version}),
+    arangodb3e-client (> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}

--- a/debian/default/enterprise/control
+++ b/debian/default/enterprise/control
@@ -43,7 +43,7 @@ Conflicts:
     arangodb3e (< ${binary:Version}),
     arangodb3e (> ${binary:Version})
 Depends:
-    arangodb3e (= ${binary:Version}),
+    arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb
  A distributed free and open-source database with a flexible data model for documents,

--- a/debian/default/enterprise/control
+++ b/debian/default/enterprise/control
@@ -44,7 +44,7 @@ Conflicts:
     arangodb3e (>> ${binary:Version}),
     arangodb3e-client (<< ${binary:Version}),
     arangodb3e-client (>> ${binary:Version})
-Pre-Depends:$
+Pre-Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}
 Description: debugging symbols for arangodb

--- a/debian/default/enterprise/control
+++ b/debian/default/enterprise/control
@@ -40,10 +40,10 @@ Conflicts:
     arangodb3,
     arangodb3-client,
     arangodb3-dbg,
-    arangodb3e (< ${binary:Version}),
-    arangodb3e (> ${binary:Version}),
-    arangodb3e-client (< ${binary:Version}),
-    arangodb3e-client (> ${binary:Version})
+    arangodb3e (<< ${binary:Version}),
+    arangodb3e (>> ${binary:Version}),
+    arangodb3e-client (<< ${binary:Version}),
+    arangodb3e-client (>> ${binary:Version})
 Depends:
     arangodb3e (= ${binary:Version}) | arangodb3e-client (= ${binary:Version}),
     ${misc:Depends}


### PR DESCRIPTION
Fix of https://github.com/arangodb/release-qa/issues/329#issuecomment-658156838 and https://github.com/arangodb/release-qa/issues/329#issuecomment-658160011 behavior for 3.4, 3.5, 3.6, 3.7 and devel Debian dbg packages.

- [x] 3.4: http://jenkins.arangodb.biz:8080/job/arangodb-ANY-linux-packages/955/
- [x] 3.5: http://jenkins.arangodb.biz:8080/job/arangodb-ANY-linux-packages/956/
- [x] 3.6: http://jenkins.arangodb.biz:8080/job/arangodb-ANY-linux-packages/957/
- [x] 3.7: http://jenkins.arangodb.biz:8080/job/arangodb-ANY-linux-packages/958/
- [x] devel: http://jenkins.arangodb.biz:8080/job/arangodb-ANY-linux-packages/961/ (with https://github.com/arangodb/arangodb/pull/12433)