### PR TITLE
Fix RPM repo path for Hotfixes

### DIFF
--- a/scripts/createRepo
+++ b/scripts/createRepo
@@ -65,10 +65,10 @@ provided(){
 create_repo(){
     #set -x
     provided "$@"
-    local version="$1"                     # X.Y.Z[-(alpha | beta | milestone | rc).R]
+    local version="$1"                     # X.Y.Z[-(H | (alpha | beta | milestone | rc).R)]
     local major_minor=$(expr "$version" : '\([0-9].[0-9]\)')      # X.Y
     local version_fs="${major_minor/./}"   # XY[-(alpha | beta | milestone | rc).R]
-    [[ "${version%%-*}" = "${version}" ]] || version_fs="${version_fs}-${version#*-}"
+    [[ "${version%%-*}" = "${version}" ]] || [[ "${version##*-}" =~ ^[1-9]+$ ]] || version_fs="${version_fs}-${version##*-}"
     local in_path="$2"                     # /mnt/data/fileserver
     local repo_path="$3"                   # /mnt/data/localstage
     local in_name="$4"                     # debianjessie


### PR DESCRIPTION
Include case for Hotfix releases.

The following jobs were executed to fix repo using this branch:
- 3.6: http://jenkins01.arangodb.biz:8080/job/arangodb-RELEASE-405---create-repositories/140/
- 3.7: http://jenkins01.arangodb.biz:8080/job/arangodb-RELEASE-405---create-repositories/141/

The following job should be executed (for both 3.6 and 3.7) to resync repo to web-site after merging this branch:
- http://jenkins01.arangodb.biz:8080/view/Release/job/arangodb-RELEASE-508---upload-files-all/