### PR TITLE
add restart test suite

### DIFF
--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -176,6 +176,7 @@ set CT "$CT""500,runClusterTest1 authentication 0 --testBuckets 3/0 --dumpAgency
 set CT "$CT""500,runClusterTest1 authentication 1 --testBuckets 3/1 --dumpAgencyOnError true\n"
 set CT "$CT""500,runClusterTest1 authentication 2 --testBuckets 3/2 --dumpAgencyOnError true\n"
 set CT "$CT""750,runClusterTest1 http_server - --dumpAgencyOnError true\n"
+set CT "$CT""1000,runClusterTest1 restart - --dumpAgencyOnError true\n"
 set CT "$CT""1000,runClusterTest1 server_secrets - --dumpAgencyOnError true\n"
 set CT "$CT""1000,runClusterTest1 server_permissions - --dumpAgencyOnError true\n"
 set CT "$CT""1000,runClusterTest1 server_parameters - --dumpAgencyOnError true\n"

--- a/scripts/runFullTests.ps1
+++ b/scripts/runFullTests.ps1
@@ -125,6 +125,7 @@ Function global:registerClusterTests()
     registerTest -cluster $true -testname "shell_client"
     registerTest -cluster $true -testname "shell_server"
     registerTest -cluster $true -testname "http_server" -sniff true
+    registerTest -cluster $true -testname "restart"
     registerTest -cluster $true -testname "server_secrets"
     registerTest -cluster $true -testname "server_permissions"
     registerTest -cluster $true -testname "server_parameters"

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -141,6 +141,7 @@ set CT "$CT""1500,runClusterTest1 shell_server_aql 14 --testBuckets 16/14 --dump
 set CT "$CT""1500,runClusterTest1 shell_server_aql 15 --testBuckets 16/15 --dumpAgencyOnError true\n"
 set CT "$CT""500,runClusterTest1 server_http - --dumpAgencyOnError true\n"
 set CT "$CT""500,runClusterTest1 server_secrets - --dumpAgencyOnError true\n"
+set CT "$CT""1000,runClusterTest1 restart - --dumpAgencyOnError true\n"
 set CT "$CT""1000,runClusterTest1 server_permissions - --dumpAgencyOnError true\n"
 set CT "$CT""1000,runClusterTest1 server_parameters - --dumpAgencyOnError true\n"
 set CT "$CT""1000,runClusterTest1 ssl_server - --dumpAgencyOnError true\n"

--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -104,6 +104,7 @@ Function global:registerClusterTests()
     registerTest -cluster $true -testname "resilience_failover"
     registerTest -cluster $true -testname "resilience_sharddist"
     registerTest -cluster $true -testname "resilience_analyzers"
+    registerTest -cluster $true -testname "restart"
     registerTest -cluster $true -testname "shell_client"
     registerTest -cluster $true -testname "shell_server_aql" -index "0" -bucket "5/0"
     registerTest -cluster $true -testname "shell_server_aql" -index "1" -bucket "5/1"


### PR DESCRIPTION
Accompanying Oskar PR for
https://github.com/arangodb/arangodb/pull/12770
https://github.com/arangodb/arangodb/pull/12772
https://github.com/arangodb/arangodb/pull/12771

This PR adds the `restart` test suite for execution in cluster.
This test suite is intended to be run in 3.6, 3.7 and devel once the above PRs got merged.
There is an additional PR for 3.5 that adds `restart` to the blocklist in that version: https://github.com/arangodb/arangodb/pull/12878