### PR TITLE
remove obsolete UNCONDITIONALLY_BUILD_LOG_MESSAGES variable

### DIFF
--- a/helper.fish
+++ b/helper.fish
@@ -339,8 +339,10 @@ function oskarCompile
   showConfig
   showRepository
   set -x NOSTRIP 1
+  
+  # note: DEBUG_SYNC_REPLICATION is removed from 3.8 onwards an can be removed here too soon 
   if test "$ASAN" = "On"
-    buildArangoDB -DUSE_FAILURE_TESTS=On -DDEBUG_SYNC_REPLICATION=On -DUNCONDITIONALLY_BUILD_LOG_MESSAGES=On ; or return $status
+    buildArangoDB -DUSE_FAILURE_TESTS=On -DDEBUG_SYNC_REPLICATION=On ; or return $status
   else
     buildStaticArangoDB -DUSE_FAILURE_TESTS=On -DDEBUG_SYNC_REPLICATION=On ; or return $status
   end

--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -373,8 +373,9 @@ function makeStaticArangoDB
 end
 
 function buildStaticCoverage
+  # note: DEBUG_SYNC_REPLICATION is removed from 3.8 onwards an can be removed here too soon 
   coverageOn
-  and buildStaticArangoDB -DUSE_FAILURE_TESTS=On -DDEBUG_SYNC_REPLICATION=On -DUNCONDITIONALLY_BUILD_LOG_MESSAGES=On
+  and buildStaticArangoDB -DUSE_FAILURE_TESTS=On -DDEBUG_SYNC_REPLICATION=On 
 end
 
 function buildExamples


### PR DESCRIPTION
Removes CMake control variable `UNCONDITIONALLY_BUILD_LOG_MESSAGES` from oskar scripts.

Now, any maintainer mode build in devel will build all log messages automatically, so we will have full coverage of log message construction during our tests. In non-maintainer mode, log messages are still only built when actually required. This simplifies the build and increases coverage.

This accompanies arangodb/arangodb bugfix https://github.com/arangodb/arangodb/pull/13870.