### PR TITLE
Immediately remove recursiveChown container on Linux

### DIFF
--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -1299,6 +1299,7 @@ function runInContainer
       -e UID=(id -u) \
       -e GID=(id -g) \
       -e INNERWORKDIR=$INNERWORKDIR \
+      --rm \
       $ALPINEUTILSIMAGE $SCRIPTSDIR/recursiveChown.fish
 
   if test -n "$agentstarted"


### PR DESCRIPTION
We use a Docker container to recursively chown data after another
container run. This container will never be needed again and thus
should be called with `--rm`. This PR adds this option.
