### PR TITLE
Update ubi8/ubi-minimal to 8.4 in containers

### DIFF
--- a/containers/arangodb36ubi.docker/Dockerfile
+++ b/containers/arangodb36ubi.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 MAINTAINER Frank Celler <info@arangodb.com>
 
 RUN microdnf update -y && rm -rf /var/cache/yum

--- a/containers/arangodb37ubi.docker/Dockerfile
+++ b/containers/arangodb37ubi.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 MAINTAINER Frank Celler <info@arangodb.com>
 
 RUN microdnf update -y && rm -rf /var/cache/yum

--- a/containers/arangodb38ubi.docker/Dockerfile
+++ b/containers/arangodb38ubi.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 MAINTAINER Frank Celler <info@arangodb.com>
 
 RUN microdnf update -y && rm -rf /var/cache/yum

--- a/containers/arangodbDevelubi.docker/Dockerfile
+++ b/containers/arangodbDevelubi.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 MAINTAINER Frank Celler <info@arangodb.com>
 
 RUN microdnf update -y && rm -rf /var/cache/yum


### PR DESCRIPTION
For all supported branches starting nearest releases (3.6.14, 3.7.13, 3.8.0) plus all nightly packages.

- 3.6: http://jenkins01.arangodb.biz:8080/view/3.6/job/arangodb-3.6-docker-and-drivers-nightly/253/
  - docker.io/arangodb/enterprise-preview:3.6-pr324
  - gcr.io/gcr-for-testing/arangodb/enterprise-preview:3.6-pr324

- 3.7: http://jenkins01.arangodb.biz:8080/view/3.7/job/arangodb-3.7-docker-and-drivers-nightly/376/
  - docker.io/arangodb/enterprise-preview:3.7-pr324
  - gcr.io/gcr-for-testing/arangodb/enterprise-preview:3.7-pr324

- 3.8: http://jenkins01.arangodb.biz:8080/view/3.8/job/arangodb-3.8-docker-and-drivers-nightly/90/
  - docker.io/arangodb/enterprise-preview:3.8-pr324
  - gcr.io/gcr-for-testing/arangodb/enterprise-preview:3.8-pr324

- devel: http://jenkins01.arangodb.biz:8080/view/3.devel/job/arangodb-devel-docker-and-drivers-nightly/425/
  - docker.io/arangodb/enterprise-preview:devel-pr324
  - gcr.io/gcr-for-testing/arangodb/enterprise-preview:devel-pr324