### PR TITLE
Add chaos test suite to tests.

### DIFF
--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -209,6 +209,7 @@ set CT "$CT""250,runClusterTest1 dump_encrypted - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 dump_with_crashes - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 hot_backup - --dumpAgencyOnError true\n"
 set ST "$CT""250,runClusterTest1 arangobench - --dumpAgencyOnError true\n"
+set ST "$CT""250,runClusterTest1 chaos - --dumpAgencyOnError true --skipNightly false\n"
 
 set -g CTS (echo -e $CT | fgrep , | sort -rn | awk -F, '{print $2}')
 set -g CTL (count $CTS)

--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -208,8 +208,8 @@ set CT "$CT""250,runClusterTest1 dump_no_envelope - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 dump_encrypted - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 dump_with_crashes - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 hot_backup - --dumpAgencyOnError true\n"
-set ST "$CT""250,runClusterTest1 arangobench - --dumpAgencyOnError true\n"
-set ST "$CT""250,runClusterTest1 chaos - --dumpAgencyOnError true --skipNightly false\n"
+set CT "$CT""250,runClusterTest1 arangobench - --dumpAgencyOnError true\n"
+set CT "$CT""250,runClusterTest1 chaos - --dumpAgencyOnError true --skipNightly false\n"
 
 set -g CTS (echo -e $CT | fgrep , | sort -rn | awk -F, '{print $2}')
 set -g CTL (count $CTS)

--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -209,7 +209,7 @@ set CT "$CT""250,runClusterTest1 dump_encrypted - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 dump_with_crashes - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 hot_backup - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 arangobench - --dumpAgencyOnError true\n"
-set CT "$CT""4800,runClusterTest1 chaos - --dumpAgencyOnError true --skipNightly false\n"
+set CT "$CT""9600,runClusterTest1 chaos - --dumpAgencyOnError true --skipNightly false\n"
 
 set -g CTS (echo -e $CT | fgrep , | sort -rn | awk -F, '{print $2}')
 set -g CTL (count $CTS)

--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -209,7 +209,7 @@ set CT "$CT""250,runClusterTest1 dump_encrypted - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 dump_with_crashes - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 hot_backup - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 arangobench - --dumpAgencyOnError true\n"
-set CT "$CT""250,runClusterTest1 chaos - --dumpAgencyOnError true --skipNightly false\n"
+set CT "$CT""4800,runClusterTest1 chaos - --dumpAgencyOnError true --skipNightly false\n"
 
 set -g CTS (echo -e $CT | fgrep , | sort -rn | awk -F, '{print $2}')
 set -g CTL (count $CTS)

--- a/scripts/runFullTests.ps1
+++ b/scripts/runFullTests.ps1
@@ -156,6 +156,7 @@ Function global:registerClusterTests()
     registerTest -cluster $true -testname "audit_client"
     registerTest -cluster $true -testname "audit_server"
     registerTest -cluster $true -testname "arangobench"
+    registerTest -cluster $true -testname "chaos" -skipNightly "false"
     # registerTest -cluster $true -testname "agency" -weight 2
     # Note that we intentionally do not register the hot_backup test here,
     # since it is currently not supported on Windows. The reason is that

--- a/scripts/runFullTests.ps1
+++ b/scripts/runFullTests.ps1
@@ -156,7 +156,7 @@ Function global:registerClusterTests()
     registerTest -cluster $true -testname "audit_client"
     registerTest -cluster $true -testname "audit_server"
     registerTest -cluster $true -testname "arangobench"
-    registerTest -cluster $true -testname "chaos" -skipNightly "false"
+    registerTest -cluster $true -testname "chaos" -moreParams "--skipNightly false"
     # registerTest -cluster $true -testname "agency" -weight 2
     # Note that we intentionally do not register the hot_backup test here,
     # since it is currently not supported on Windows. The reason is that

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -173,6 +173,7 @@ set CT "$CT""250,runClusterTest1 dump_with_crashes - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 export - --dumpAgencyOnError true\n"
 set CT "$CT""750,runClusterTest1 http_server - --dumpAgencyOnError true\n"
 set CT "$CT""250,runClusterTest1 hot_backup - --dumpAgencyOnError true\n"
+set CT "$CT""250,runClusterTest1 chaos - --dumpAgencyOnError true\n"
 
 set -g CTS (echo -e $CT | fgrep , | sort -rn | awk -F, '{print $2}')
 set -g CTL (count $CTS)

--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -128,6 +128,7 @@ Function global:registerClusterTests()
     registerTest -cluster $true -testname "ssl_server"
     registerTest -cluster $true -testname "audit_client"
     registerTest -cluster $true -testname "audit_server"
+    registerTest -cluster $true -testname "chaos"
     # Note that we intentionally do not register the hot_backup test here,
     # since it is currently not supported on Windows. The reason is that
     # the testing framework does not support automatic restarts of instances


### PR DESCRIPTION
Add `chaos` test suite. This test suite is present in devel, 3.8 and 3.7.

Accompanying PR for
  * https://github.com/arangodb/arangodb/pull/14406
  * https://github.com/arangodb/arangodb/pull/14417
  * https://github.com/arangodb/arangodb/pull/14420

Blocklist PRs for older branches:
* 3.6: https://github.com/arangodb/arangodb/pull/14421