### PR TITLE
Update ArangoDB images to Alpine 3.14

### DIFF
--- a/containers/arangodb36.docker/Dockerfile
+++ b/containers/arangodb36.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 MAINTAINER Max Neunhoeffer <max@arangodb.com>
 
 RUN apk add --no-cache pwgen binutils numactl numactl-tools

--- a/containers/arangodb37.docker/Dockerfile
+++ b/containers/arangodb37.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.14
 MAINTAINER Max Neunhoeffer <max@arangodb.com>
 
 RUN apk add --no-cache pwgen nodejs binutils numactl numactl-tools

--- a/containers/arangodb38.docker/Dockerfile
+++ b/containers/arangodb38.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.14
 MAINTAINER Max Neunhoeffer <hackers@arangodb.com>
 
 RUN apk add --no-cache pwgen nodejs binutils numactl numactl-tools

--- a/containers/arangodbDevel.docker/Dockerfile
+++ b/containers/arangodbDevel.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.14
 MAINTAINER Max Neunhoeffer <hackers@arangodb.com>
 
 RUN apk add --no-cache pwgen nodejs binutils numactl numactl-tools


### PR DESCRIPTION
An attempt to raise Alpine version to 3.14 in all supported ArangoDB branches to get rid of `binutils` CVEs.

Jenkins:
 - Tests:
   - 3.6: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/31/
   - 3.7: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/30/, http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-spring-data-matrix/1616/
   - 3.8: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/29/
   - devel: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/28/, http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-php-driver-matrix/1787/
 - Packages:
   - 3.6: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-packages/1360/
   - 3.7: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-packages/1361/
   - 3.8: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-packages/1362/
   - devel: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-packages/1363/