### PR TITLE
exclude lines containing TRI_ASSERT from coverage

### DIFF
--- a/scripts/coverage.fish
+++ b/scripts/coverage.fish
@@ -49,6 +49,7 @@ and gcovr --exclude-throw-branches --root /work/ArangoDB \
         -e /work/ArangoDB/tests \
         -e include/jemalloc/internal \
         -o coverage/coverage.xml \
+        --exclude-lines-by-pattern "TRI_ASSERT" \
         --print-summary \
         /work/combined/result > /work/coverage/summary.txt
 and cat coverage/coverage.xml \


### PR DESCRIPTION
We have a few things that we would like to exclude from coverage reports, e.g. assertions. The problem is that our assertions are implemented using macros. Using the gcov exclusion markers GCOVR_EXCL_... in our source code unfortunately doesn't help, as gcov looks at the raw source code and not the preprocessed source files.
This PR is a best-effort attempt to still exclude assertions from
coverage, by simply telling gcov that any lines containing `TRI_ASSERT`
should be excluded. That seems to be the only way of excluding these
lines without turning the TRI_ASSERT macro into a function call in our
source code.
This will not handle multi-line assertion statements very well, but it
is probably still better than nothing. In addition, if we ever change
the macro name from TRI_ASSERT to something else, we need to adjust it
here too.