### PR TITLE
Attempt to remove binutils from Alpine-based ArangoDB docker images

### DIFF
--- a/containers/arangodb36.docker/Dockerfile
+++ b/containers/arangodb36.docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 MAINTAINER Max Neunhoeffer <max@arangodb.com>
 
-RUN apk add --no-cache pwgen binutils numactl numactl-tools
+RUN apk add --no-cache pwgen numactl numactl-tools
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.11/main/ nodejs
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.11/main/ npm && npm install -g foxx-cli && apk del npm
 

--- a/containers/arangodb37.docker/Dockerfile
+++ b/containers/arangodb37.docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 MAINTAINER Max Neunhoeffer <max@arangodb.com>
 
-RUN apk add --no-cache pwgen nodejs binutils numactl numactl-tools
+RUN apk add --no-cache pwgen nodejs numactl numactl-tools
 RUN apk add --no-cache npm && npm install -g foxx-cli && apk del npm
 
 ENV GLIBCXX_FORCE_NEW=1

--- a/containers/arangodb38.docker/Dockerfile
+++ b/containers/arangodb38.docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 MAINTAINER Max Neunhoeffer <hackers@arangodb.com>
 
-RUN apk add --no-cache pwgen nodejs binutils numactl numactl-tools
+RUN apk add --no-cache pwgen nodejs numactl numactl-tools
 RUN apk add --no-cache npm && npm install -g foxx-cli && apk del npm
 
 ENV GLIBCXX_FORCE_NEW=1

--- a/containers/arangodbDevel.docker/Dockerfile
+++ b/containers/arangodbDevel.docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 MAINTAINER Max Neunhoeffer <hackers@arangodb.com>
 
-RUN apk add --no-cache pwgen nodejs binutils numactl numactl-tools
+RUN apk add --no-cache pwgen nodejs numactl numactl-tools
 RUN apk add --no-cache npm && npm install -g foxx-cli && apk del npm
 
 ENV GLIBCXX_FORCE_NEW=1


### PR DESCRIPTION
An attempt to get rid of `binutils` in Alpine docker images of all supported ArangoDB branches: less possible CVEs and reduce of used storage amount is expected.

Jenkins:
 - Tests:
   - 3.6: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/35/
   - 3.7: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/34/, http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-java-driver-matrix/1988/, http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-spark-connector-matrix/1717/
   - 3.8: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/33/
   - devel: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-and-drivers/32/
 - Packages:
   - 3.6: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-packages/1364/
   - 3.7: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-packages/1365/
   - 3.8: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-packages/1366/
   - devel: http://jenkins01.arangodb.biz:8080/job/arangodb-ANY-docker-packages/1367/