### PR TITLE
Fix ^ redirections for fish 3.3+

### DIFF
--- a/helper.fish
+++ b/helper.fish
@@ -7,13 +7,13 @@ function lockDirectory
     echo $pid > LOCK.$pid
     and while true
       # Remove a stale lock if it is found:
-      if set -l pidfound (cat LOCK ^/dev/null)
+      if set -l pidfound (cat LOCK > /dev/null)
         if not ps ax -o pid | grep '^ *'"$pidfound"'$' > /dev/null
           rm LOCK LOCK.$pidfound
           and echo Have removed stale lock.
         end
       end
-      and if ln LOCK.$pid LOCK ^/dev/null
+      and if ln LOCK.$pid LOCK > /dev/null
         break
       end
       and echo -n Directory is locked, waiting...

--- a/jenkins/helper/jenkins.fish
+++ b/jenkins/helper/jenkins.fish
@@ -20,7 +20,7 @@ function prepareOskar
 
   git config --global http.postBuffer 524288000
   and git config --global https.postBuffer 524288000
-  and if not cd $OSKAR ^ /dev/null
+  and if not cd $OSKAR > /dev/null
     echo clone --progress  -b $OSKAR_BRANCH ssh://git@github.com/arangodb/oskar $OSKAR
     git clone --progress  -b $OSKAR_BRANCH ssh://git@github.com/arangodb/oskar $OSKAR ; and cd $OSKAR
   else


### PR DESCRIPTION
```
Redirection to standard error with the ^ character has been disabled by default. It can be turned back on using the stderr-nocaret feature flag, but will eventually be disabled completely (#7105).
```

Starting https://github.com/fish-shell/fish-shell/releases/tag/3.3.0.

Should be backward compatible.