### PR TITLE
Fix false match with windows gce nodes

### DIFF
--- a/helper.psm1
+++ b/helper.psm1
@@ -973,7 +973,7 @@ Function downloadStarter
 {
     Write-Host "Time: $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH.mm.ssZ'))"
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    (Select-String -Path "$global:ARANGODIR\VERSIONS" -SimpleMatch "STARTER_REV")[0] -match '([0-9]+.[0-9]+.[0-9]+[\-]?[0-9a-z]*[\-]?[0-9]?)|latest' | Out-Null
+    (Select-String -Path "$global:ARANGODIR\VERSIONS" -SimpleMatch "STARTER_REV").Line -match '([0-9]+.[0-9]+.[0-9]+[\-]?[0-9a-z]*[\-]?[0-9]?)|latest' | Out-Null
     $STARTER_REV = $Matches[0]
     If($STARTER_REV -eq "latest")
     {
@@ -992,7 +992,7 @@ Function downloadSyncer
     {
         Write-Host "Need  environment variable set!"
     }
-    (Select-String -Path "$global:ARANGODIR\VERSIONS" -SimpleMatch "SYNCER_REV")[0] -match '([0-9]+.[0-9]+.[0-9]+)|latest' | Out-Null
+    (Select-String -Path "$global:ARANGODIR\VERSIONS" -SimpleMatch "SYNCER_REV").Line -match '([0-9]+.[0-9]+.[0-9]+)|latest' | Out-Null
     $SYNCER_REV = $Matches[0]
     If($SYNCER_REV -eq "latest")
     {


### PR DESCRIPTION
In windows gce nodes it is possible to have ids inside the path which can cause a false match and breakes the download of starter and syncer. With this fix the FullPath is not used anymore only the needed line from the versions file.