### PR TITLE
Increase overall timeout on Windows from 4200 to 6000

### DIFF
--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -90,7 +90,7 @@ Function global:registerClusterTests()
     noteStartAndRepoState
     Write-Host "Registering tests..."
 
-    $global:TESTSUITE_TIMEOUT = 4200
+    $global:TESTSUITE_TIMEOUT = 6000
 
     registerTest -cluster $true -testname "load_balancing"
     registerTest -cluster $true -testname "load_balancing_auth"


### PR DESCRIPTION
This is an emergency measure to unblock people and make more test runs
green, because we see frequent timeouts.

This has to be sorted out eventually in some other way, since PR tests
run for too long anyway.
