### PR TITLE
REVERT: Increase overall timeout on Windows from 4200 to 6000

### DIFF
--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -90,7 +90,7 @@ Function global:registerClusterTests()
     noteStartAndRepoState
     Write-Host "Registering tests..."
 
-    $global:TESTSUITE_TIMEOUT = 6000
+    $global:TESTSUITE_TIMEOUT = 4200
 
     registerTest -cluster $true -testname "load_balancing"
     registerTest -cluster $true -testname "load_balancing_auth"


### PR DESCRIPTION
This reverts https://github.com/arangodb/oskar/pull/341 which was only
a temporary measure to get people going again.

WARNING: Do not merge this unless we have done something against the
time Windows tests need, otherwise Jenkins will be unstable again!!!
