### PR TITLE
Remove deprecated which command

### DIFF
--- a/binForTarGz/arangobackup
+++ b/binForTarGz/arangobackup
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else
   realpath() {

--- a/binForTarGz/arangobench
+++ b/binForTarGz/arangobench
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else 
   realpath() {

--- a/binForTarGz/arangod
+++ b/binForTarGz/arangod
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else 
   realpath() {

--- a/binForTarGz/arangodb
+++ b/binForTarGz/arangodb
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else 
   realpath() {

--- a/binForTarGz/arangodump
+++ b/binForTarGz/arangodump
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else 
   realpath() {

--- a/binForTarGz/arangoexport
+++ b/binForTarGz/arangoexport
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else 
   realpath() {

--- a/binForTarGz/arangoimp
+++ b/binForTarGz/arangoimp
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else 
   realpath() {

--- a/binForTarGz/arangoimport
+++ b/binForTarGz/arangoimport
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else 
   realpath() {

--- a/binForTarGz/arangoinspect
+++ b/binForTarGz/arangoinspect
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else 
   realpath() {

--- a/binForTarGz/arangorestore
+++ b/binForTarGz/arangorestore
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else 
   realpath() {

--- a/binForTarGz/arangosh
+++ b/binForTarGz/arangosh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else 
   realpath() {

--- a/binForTarGz/arangosync
+++ b/binForTarGz/arangosync
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else 
   realpath() {

--- a/binForTarGz/arangovpack
+++ b/binForTarGz/arangovpack
@@ -1,5 +1,5 @@
 #!/bin/sh
-if which realpath > /dev/null; then
+if command -v realpath > /dev/null; then
   true
 else 
   realpath() {


### PR DESCRIPTION
Turn deprecated `which` command to `command -v`.

Jenkins: https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/17681/
Packages: https://jenkins.arangodb.biz/job/arangodb-ANY-packages/38/