### PR TITLE
add linbreak to error message

### DIFF
--- a/scripts/lib/Utils.psm1
+++ b/scripts/lib/Utils.psm1
@@ -378,7 +378,7 @@ Function LaunchController($seconds)
     $SessionId = [System.Diagnostics.Process]::GetCurrentProcess().SessionId
     ForEach ($test in $global:launcheableTests) {
         If ($test['pid'] -gt 0 -And $test['running'] -And (Get-Process -Id $test['pid'] -ErrorAction SilentlyContinue)) {
-            $global:oskarErrorMessage = $global:oskarErrorMessage + "Oskar is killing this test due to timeout: " + $test['testname']
+            $global:oskarErrorMessage = $global:oskarErrorMessage + "Oskar is killing this test due to timeout: " + $test['testname'] + "`n"
             Write-Host "Testrun timeout:"
             $str = $($test | where {($_.Name -ne "commandline")} | Out-String)
             Write-Host $str


### PR DESCRIPTION
as seen in http://jenkins01.arangodb.biz:8080/job/arangodb-matrix-pr-windows/10740/EDITION=community,STORAGE_ENGINE=rocksdb,TEST_SUITE=cluster,limit=windows&&test&&!rta/
there is a linebreak missing here.

according to SO its done like this.
https://stackoverflow.com/questions/11876901/how-to-break-lines-in-powershell