### PR TITLE
Fix logrotate group (issue #13935) and copyright dates

### DIFF
--- a/debian/3.6/community/control
+++ b/debian/3.6/community/control
@@ -14,7 +14,7 @@ Description: a multi-model NoSQL database
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 
@@ -28,7 +28,7 @@ Description: stand-alone shell
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 

--- a/debian/3.6/community/copyright
+++ b/debian/3.6/community/copyright
@@ -5,7 +5,7 @@ from sources obtained from http://github.com/arangodb/ArangoDB.
 Copyright:
 
 Copyright (C) 2012-2013 triAGENS GmbH
-              2014-2019 ArangoDB GmbH
+              2014-2021 ArangoDB GmbH
 
 License:
 

--- a/debian/3.6/enterprise/control
+++ b/debian/3.6/enterprise/control
@@ -14,7 +14,7 @@ Description: a multi-model NoSQL database
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 
@@ -28,7 +28,7 @@ Description: stand-alone shell
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 

--- a/debian/3.6/enterprise/copyright
+++ b/debian/3.6/enterprise/copyright
@@ -5,7 +5,7 @@ from sources obtained from http://github.com/arangodb/ArangoDB.
 Copyright:
 
 Copyright (C) 2012-2013 triAGENS GmbH
-              2014-2019 ArangoDB GmbH
+              2014-2021 ArangoDB GmbH
 
 License:
 

--- a/debian/3.7/community/control
+++ b/debian/3.7/community/control
@@ -14,7 +14,7 @@ Description: a multi-model NoSQL database
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 
@@ -28,7 +28,7 @@ Description: stand-alone shell
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 

--- a/debian/3.7/community/copyright
+++ b/debian/3.7/community/copyright
@@ -5,7 +5,7 @@ from sources obtained from http://github.com/arangodb/ArangoDB.
 Copyright:
 
 Copyright (C) 2012-2013 triAGENS GmbH
-              2014-2019 ArangoDB GmbH
+              2014-2021 ArangoDB GmbH
 
 License:
 

--- a/debian/3.7/enterprise/control
+++ b/debian/3.7/enterprise/control
@@ -14,7 +14,7 @@ Description: a multi-model NoSQL database
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 
@@ -28,7 +28,7 @@ Description: stand-alone shell
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 

--- a/debian/3.7/enterprise/copyright
+++ b/debian/3.7/enterprise/copyright
@@ -5,7 +5,7 @@ from sources obtained from http://github.com/arangodb/ArangoDB.
 Copyright:
 
 Copyright (C) 2012-2013 triAGENS GmbH
-              2014-2019 ArangoDB GmbH
+              2014-2021 ArangoDB GmbH
 
 License:
 

--- a/debian/3.8/community/control
+++ b/debian/3.8/community/control
@@ -14,7 +14,7 @@ Description: a multi-model NoSQL database
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 
@@ -28,7 +28,7 @@ Description: stand-alone shell
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 

--- a/debian/3.8/community/copyright
+++ b/debian/3.8/community/copyright
@@ -5,7 +5,7 @@ from sources obtained from http://github.com/arangodb/ArangoDB.
 Copyright:
 
 Copyright (C) 2012-2013 triAGENS GmbH
-              2014-2019 ArangoDB GmbH
+              2014-2021 ArangoDB GmbH
 
 License:
 

--- a/debian/3.8/enterprise/control
+++ b/debian/3.8/enterprise/control
@@ -14,7 +14,7 @@ Description: a multi-model NoSQL database
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 
@@ -28,7 +28,7 @@ Description: stand-alone shell
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 

--- a/debian/3.8/enterprise/copyright
+++ b/debian/3.8/enterprise/copyright
@@ -5,7 +5,7 @@ from sources obtained from http://github.com/arangodb/ArangoDB.
 Copyright:
 
 Copyright (C) 2012-2013 triAGENS GmbH
-              2014-2019 ArangoDB GmbH
+              2014-2021 ArangoDB GmbH
 
 License:
 

--- a/debian/3.9/community/control
+++ b/debian/3.9/community/control
@@ -14,7 +14,7 @@ Description: a multi-model NoSQL database
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 
@@ -28,7 +28,7 @@ Description: stand-alone shell
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 

--- a/debian/3.9/community/copyright
+++ b/debian/3.9/community/copyright
@@ -5,7 +5,7 @@ from sources obtained from http://github.com/arangodb/ArangoDB.
 Copyright:
 
 Copyright (C) 2012-2013 triAGENS GmbH
-              2014-2019 ArangoDB GmbH
+              2014-2021 ArangoDB GmbH
 
 License:
 

--- a/debian/3.9/enterprise/control
+++ b/debian/3.9/enterprise/control
@@ -14,7 +14,7 @@ Description: a multi-model NoSQL database
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 
@@ -28,7 +28,7 @@ Description: stand-alone shell
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 

--- a/debian/3.9/enterprise/copyright
+++ b/debian/3.9/enterprise/copyright
@@ -5,7 +5,7 @@ from sources obtained from http://github.com/arangodb/ArangoDB.
 Copyright:
 
 Copyright (C) 2012-2013 triAGENS GmbH
-              2014-2019 ArangoDB GmbH
+              2014-2021 ArangoDB GmbH
 
 License:
 

--- a/debian/default/community/control
+++ b/debian/default/community/control
@@ -14,7 +14,7 @@ Description: a multi-model NoSQL database
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 
@@ -28,7 +28,7 @@ Description: stand-alone shell
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 

--- a/debian/default/community/copyright
+++ b/debian/default/community/copyright
@@ -5,7 +5,7 @@ from sources obtained from http://github.com/arangodb/ArangoDB.
 Copyright:
 
 Copyright (C) 2012-2013 triAGENS GmbH
-              2014-2019 ArangoDB GmbH
+              2014-2021 ArangoDB GmbH
 
 License:
 

--- a/debian/default/enterprise/control
+++ b/debian/default/enterprise/control
@@ -14,7 +14,7 @@ Description: a multi-model NoSQL database
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 
@@ -28,7 +28,7 @@ Description: stand-alone shell
  SQL-like query language or JavaScript extensions.
  .
  Copyright: 2012-2013 by triAGENS GmbH
- Copyright: 2014-2019 by ArangoDB GmbH
+ Copyright: 2014-2021 by ArangoDB GmbH
  ArangoDB Software
  www.arangodb.com
 

--- a/debian/default/enterprise/copyright
+++ b/debian/default/enterprise/copyright
@@ -5,7 +5,7 @@ from sources obtained from http://github.com/arangodb/ArangoDB.
 Copyright:
 
 Copyright (C) 2012-2013 triAGENS GmbH
-              2014-2019 ArangoDB GmbH
+              2014-2021 ArangoDB GmbH
 
 License:
 

--- a/dmg/3.6/ArangoDB3-CLI.app/Contents/Info.plist
+++ b/dmg/3.6/ArangoDB3-CLI.app/Contents/Info.plist
@@ -39,7 +39,7 @@
   <string>NO</string>
 
   <key>NSHumanReadableCopyright</key>
-  <string>Copyright © 2014-2020 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
+  <string>Copyright © 2014-2021 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>10.14</string>

--- a/dmg/3.6/ArangoDB3e-CLI.app/Contents/Info.plist
+++ b/dmg/3.6/ArangoDB3e-CLI.app/Contents/Info.plist
@@ -39,7 +39,7 @@
   <string>NO</string>
 
   <key>NSHumanReadableCopyright</key>
-  <string>Copyright © 2014-2020 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
+  <string>Copyright © 2014-2021 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>10.9</string>

--- a/dmg/3.7/ArangoDB3-CLI.app/Contents/Info.plist
+++ b/dmg/3.7/ArangoDB3-CLI.app/Contents/Info.plist
@@ -39,7 +39,7 @@
   <string>NO</string>
 
   <key>NSHumanReadableCopyright</key>
-  <string>Copyright © 2014-2020 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
+  <string>Copyright © 2014-2021 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>10.14</string>

--- a/dmg/3.7/ArangoDB3e-CLI.app/Contents/Info.plist
+++ b/dmg/3.7/ArangoDB3e-CLI.app/Contents/Info.plist
@@ -39,7 +39,7 @@
   <string>NO</string>
 
   <key>NSHumanReadableCopyright</key>
-  <string>Copyright © 2014-2020 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
+  <string>Copyright © 2014-2021 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>10.9</string>

--- a/dmg/3.8/ArangoDB3-CLI.app/Contents/Info.plist
+++ b/dmg/3.8/ArangoDB3-CLI.app/Contents/Info.plist
@@ -39,7 +39,7 @@
   <string>NO</string>
 
   <key>NSHumanReadableCopyright</key>
-  <string>Copyright © 2014-2020 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
+  <string>Copyright © 2014-2021 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>10.14</string>

--- a/dmg/3.8/ArangoDB3e-CLI.app/Contents/Info.plist
+++ b/dmg/3.8/ArangoDB3e-CLI.app/Contents/Info.plist
@@ -39,7 +39,7 @@
   <string>NO</string>
 
   <key>NSHumanReadableCopyright</key>
-  <string>Copyright © 2014-2020 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
+  <string>Copyright © 2014-2021 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>10.9</string>

--- a/dmg/3.9/ArangoDB3-CLI.app/Contents/Info.plist
+++ b/dmg/3.9/ArangoDB3-CLI.app/Contents/Info.plist
@@ -39,7 +39,7 @@
   <string>NO</string>
 
   <key>NSHumanReadableCopyright</key>
-  <string>Copyright © 2014-2020 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
+  <string>Copyright © 2014-2021 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>10.14</string>

--- a/dmg/3.9/ArangoDB3e-CLI.app/Contents/Info.plist
+++ b/dmg/3.9/ArangoDB3e-CLI.app/Contents/Info.plist
@@ -39,7 +39,7 @@
   <string>NO</string>
 
   <key>NSHumanReadableCopyright</key>
-  <string>Copyright © 2014-2020 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
+  <string>Copyright © 2014-2021 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>10.9</string>

--- a/dmg/default/ArangoDB3-CLI.app/Contents/Info.plist
+++ b/dmg/default/ArangoDB3-CLI.app/Contents/Info.plist
@@ -39,7 +39,7 @@
   <string>NO</string>
 
   <key>NSHumanReadableCopyright</key>
-  <string>Copyright © 2014-2020 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
+  <string>Copyright © 2014-2021 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>10.14</string>

--- a/dmg/default/ArangoDB3e-CLI.app/Contents/Info.plist
+++ b/dmg/default/ArangoDB3e-CLI.app/Contents/Info.plist
@@ -39,7 +39,7 @@
   <string>NO</string>
 
   <key>NSHumanReadableCopyright</key>
-  <string>Copyright © 2014-2020 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
+  <string>Copyright © 2014-2021 ArangoDB GmbH, Cologne, Germany. All rights reserved.</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>10.9</string>

--- a/rpm/3.6/arangodb3.logrotate
+++ b/rpm/3.6/arangodb3.logrotate
@@ -3,7 +3,7 @@
      weekly
      compress
      delaycompress
-     create 640  arangodb @LOGROTATE_GROUP@
+     create 640  arangodb arangodb
      postrotate
      if rpm -q --quiet systemd ; then
        systemctl -q is-active arangodb3 && systemctl kill --signal=SIGHUP arangodb3 

--- a/rpm/3.6/arangodb3.spec.in
+++ b/rpm/3.6/arangodb3.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package arangodb3
 #
-# Copyright (c) 2018 info@arangodb.org
+# Copyright (c) 2014-2021 info@arangodb.org
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/rpm/3.6/arangodb3e.spec.in
+++ b/rpm/3.6/arangodb3e.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package arangodb3
 #
-# Copyright (c) 2018 info@arangodb.org
+# Copyright (c) 2014-2021 info@arangodb.org
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/rpm/3.7/arangodb3.logrotate
+++ b/rpm/3.7/arangodb3.logrotate
@@ -3,7 +3,7 @@
      weekly
      compress
      delaycompress
-     create 640  arangodb @LOGROTATE_GROUP@
+     create 640  arangodb arangodb
      postrotate
      if rpm -q --quiet systemd ; then
        systemctl -q is-active arangodb3 && systemctl kill --signal=SIGHUP arangodb3 

--- a/rpm/3.7/arangodb3.spec.in
+++ b/rpm/3.7/arangodb3.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package arangodb3
 #
-# Copyright (c) 2018 info@arangodb.org
+# Copyright (c) 2014-2021 info@arangodb.org
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/rpm/3.7/arangodb3e.spec.in
+++ b/rpm/3.7/arangodb3e.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package arangodb3
 #
-# Copyright (c) 2018 info@arangodb.org
+# Copyright (c) 2014-2021 info@arangodb.org
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/rpm/3.8/arangodb3.logrotate
+++ b/rpm/3.8/arangodb3.logrotate
@@ -3,7 +3,7 @@
      weekly
      compress
      delaycompress
-     create 640  arangodb @LOGROTATE_GROUP@
+     create 640  arangodb arangodb
      postrotate
      if rpm -q --quiet systemd ; then
        systemctl -q is-active arangodb3 && systemctl kill --signal=SIGHUP arangodb3 

--- a/rpm/3.8/arangodb3.spec.in
+++ b/rpm/3.8/arangodb3.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package arangodb3
 #
-# Copyright (c) 2018 info@arangodb.org
+# Copyright (c) 2014-2021 info@arangodb.org
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/rpm/3.8/arangodb3e.spec.in
+++ b/rpm/3.8/arangodb3e.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package arangodb3
 #
-# Copyright (c) 2018 info@arangodb.org
+# Copyright (c) 2014-2021 info@arangodb.org
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/rpm/3.9/arangodb3.logrotate
+++ b/rpm/3.9/arangodb3.logrotate
@@ -3,7 +3,7 @@
      weekly
      compress
      delaycompress
-     create 640  arangodb @LOGROTATE_GROUP@
+     create 640  arangodb arangodb
      postrotate
      if rpm -q --quiet systemd ; then
        systemctl -q is-active arangodb3 && systemctl kill --signal=SIGHUP arangodb3 

--- a/rpm/3.9/arangodb3.spec.in
+++ b/rpm/3.9/arangodb3.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package arangodb3
 #
-# Copyright (c) 2018 info@arangodb.org
+# Copyright (c) 2014-2021 info@arangodb.org
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/rpm/3.9/arangodb3e.spec.in
+++ b/rpm/3.9/arangodb3e.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package arangodb3
 #
-# Copyright (c) 2018 info@arangodb.org
+# Copyright (c) 2014-2021 info@arangodb.org
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/rpm/default/arangodb3.logrotate
+++ b/rpm/default/arangodb3.logrotate
@@ -3,7 +3,7 @@
      weekly
      compress
      delaycompress
-     create 640  arangodb @LOGROTATE_GROUP@
+     create 640  arangodb arangodb
      postrotate
      if rpm -q --quiet systemd ; then
        systemctl -q is-active arangodb3 && systemctl kill --signal=SIGHUP arangodb3 

--- a/rpm/default/arangodb3.spec.in
+++ b/rpm/default/arangodb3.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package arangodb3
 #
-# Copyright (c) 2018 info@arangodb.org
+# Copyright (c) 2014-2021 info@arangodb.org
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/rpm/default/arangodb3e.spec.in
+++ b/rpm/default/arangodb3e.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package arangodb3
 #
-# Copyright (c) 2018 info@arangodb.org
+# Copyright (c) 2014-2021 info@arangodb.org
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed


### PR DESCRIPTION
This should fix https://github.com/arangodb/arangodb/issues/13935 for the next releases (3.7.17, 3.8.5, 3.9 after 3.9.0-alpha.1) and nightly and also adjust copyright dates for distributed packages.

Jenkins:
- [x] devel: http://jenkins.arangodb.biz/job/arangodb-ANY-packages/52/
- [x] 3.9: http://jenkins.arangodb.biz/job/arangodb-ANY-packages/53/
- [x] 3.8: http://jenkins.arangodb.biz/job/arangodb-ANY-packages/54/
- [x] 3.7: http://jenkins.arangodb.biz/job/arangodb-ANY-packages/55/