### PR TITLE
Add error-prone test definitions invocation through python

### DIFF
--- a/scripts/lib/Utils.psm1
+++ b/scripts/lib/Utils.psm1
@@ -137,27 +137,23 @@ Function runTests
     }
     Pop-Location
 
+    $global:result = "GOOD"
+
     Switch -Regex ($TESTSUITE)
     {
         "cluster"
         {
             registerClusterTests
-            LaunchController $global:TESTSUITE_TIMEOUT
-            createReport
             Break
         }
         "single"
         {
             registerSingleTests
-            LaunchController $global:TESTSUITE_TIMEOUT
-            createReport
             Break
         }
         "catchtest"
         {
             registerTest -testname "catch"
-            LaunchController $global:TESTSUITE_TIMEOUT
-            createReport
             Break
         }
         "resilience"
@@ -169,8 +165,6 @@ Function runTests
         "tests"
         {
             registerTests
-            LaunchController $global:TESTSUITE_TIMEOUT
-            createReport
             Break
         }
         "*"
@@ -179,6 +173,12 @@ Function runTests
             $global:result = "BAD"
             Break
         }
+    }
+
+    If ($global:result -eq "GOOD" -And $global:ok)
+    {
+        LaunchController $global:TESTSUITE_TIMEOUT
+        createReport
     }
 
     If($global:result -eq "GOOD")

--- a/scripts/lib/Utils.psm1
+++ b/scripts/lib/Utils.psm1
@@ -180,6 +180,10 @@ Function runTests
         LaunchController $global:TESTSUITE_TIMEOUT
         createReport
     }
+    Else
+    {
+        $global:result = "BAD"
+    }
 
     If($global:result -eq "GOOD")
     {

--- a/scripts/runFullTests.ps1
+++ b/scripts/runFullTests.ps1
@@ -15,7 +15,7 @@ Function global:registerSingleTests()
     Try
     {
         $out = python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 --full
-        If ($LASTEXITCODE -ne 0)
+        If ($LASTEXITCODE -eq 0)
         {
             echo $out | Invoke-Expression -ErrorAction Stop
         }
@@ -42,7 +42,7 @@ Function global:registerClusterTests()
     Try
     {
         $out = python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 --full --cluster
-        If ($LASTEXITCODE -ne 0)
+        If ($LASTEXITCODE -eq 0)
         {
             echo $out | Invoke-Expression -ErrorAction Stop
         }

--- a/scripts/runFullTests.ps1
+++ b/scripts/runFullTests.ps1
@@ -17,7 +17,7 @@ Function global:registerSingleTests()
         $out = python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 --full
         If ($LASTEXITCODE -ne 0)
         {
-            Invoke-Expression "Do-ErrorProneAction -Parameter $out"
+            echo $out | Invoke-Expression -ErrorAction Stop
         }
         Else
         {
@@ -44,7 +44,7 @@ Function global:registerClusterTests()
         $out = python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 --full --cluster
         If ($LASTEXITCODE -ne 0)
         {
-            Invoke-Expression "Do-ErrorProneAction -Parameter $out"
+            echo $out | Invoke-Expression -ErrorAction Stop
         }
         Else
         {

--- a/scripts/runFullTests.ps1
+++ b/scripts/runFullTests.ps1
@@ -12,8 +12,24 @@ Function global:registerSingleTests()
 
     $global:TESTSUITE_TIMEOUT = 9000
     Write-Host "Using test definitions from repo..."
-    python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 --full | Invoke-Expression
-    comm
+    Try
+    {
+        $out = python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 --full
+        If ($LASTEXITCODE -ne 0)
+        {
+            Invoke-Expression "Do-ErrorProneAction -Parameter $out"
+        }
+        Else
+        {
+            throw "$out"
+        }
+        Set-Variable -Name "ok" -Value $true -Scope global
+    }
+    Catch
+    {
+        Write-Host "Error: $_"
+        Set-Variable -Name "ok" -Value $false -Scope global
+    }
 }
 
 Function global:registerClusterTests()
@@ -23,8 +39,24 @@ Function global:registerClusterTests()
 
     $global:TESTSUITE_TIMEOUT = 18000
     Write-Host "Using test definitions from repo..."
-    python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 --full --cluster | Invoke-Expression
-    comm
+    Try
+    {
+        $out = python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 --full --cluster
+        If ($LASTEXITCODE -ne 0)
+        {
+            Invoke-Expression "Do-ErrorProneAction -Parameter $out"
+        }
+        Else
+        {
+            throw "$out"
+        }
+        Set-Variable -Name "ok" -Value $true -Scope global
+    }
+    Catch
+    {
+        Write-Host "Error: $_"
+        Set-Variable -Name "ok" -Value $false -Scope global
+    }
 }
 
 runTests

--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -18,7 +18,7 @@ Function global:registerSingleTests()
         $out = python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1
         If ($LASTEXITCODE -ne 0)
         {
-            Invoke-Expression "Do-ErrorProneAction -Parameter $out"
+            echo $out | Invoke-Expression -ErrorAction Stop
         }
         Else
         {
@@ -46,7 +46,7 @@ Function global:registerClusterTests()
         $out = python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 --cluster
         If ($LASTEXITCODE -ne 0)
         {
-            Invoke-Expression "Do-ErrorProneAction -Parameter $out"
+            echo $out | Invoke-Expression -ErrorAction Stop
         }
         Else
         {

--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -16,7 +16,7 @@ Function global:registerSingleTests()
     Try
     {
         $out = python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1
-        If ($LASTEXITCODE -ne 0)
+        If ($LASTEXITCODE -eq 0)
         {
             echo $out | Invoke-Expression -ErrorAction Stop
         }
@@ -44,7 +44,7 @@ Function global:registerClusterTests()
     Try
     {
         $out = python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 --cluster
-        If ($LASTEXITCODE -ne 0)
+        If ($LASTEXITCODE -eq 0)
         {
             echo $out | Invoke-Expression -ErrorAction Stop
         }

--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -13,8 +13,24 @@ Function global:registerSingleTests()
     $global:TESTSUITE_TIMEOUT = 3900
 
     Write-Host "Using test definitions from repo..."
-    python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 | Invoke-Expression
-    comm
+    Try
+    {
+        $out = python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1
+        If ($LASTEXITCODE -ne 0)
+        {
+            Invoke-Expression "Do-ErrorProneAction -Parameter $out"
+        }
+        Else
+        {
+            throw "$out"
+        }
+        Set-Variable -Name "ok" -Value $true -Scope global
+    }
+    Catch
+    {
+        Write-Host "Error: $_"
+        Set-Variable -Name "ok" -Value $false -Scope global
+    }
 }
 
 Function global:registerClusterTests()
@@ -25,8 +41,24 @@ Function global:registerClusterTests()
     $global:TESTSUITE_TIMEOUT = 6000
 
     Write-Host "Using test definitions from repo..."
-    python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 --cluster | Invoke-Expression
-    comm
+    Try
+    {
+        $out = python "$env:WORKSPACE\jenkins\helper\generate_jenkins_scripts.py" "$INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -f ps1 --cluster
+        If ($LASTEXITCODE -ne 0)
+        {
+            Invoke-Expression "Do-ErrorProneAction -Parameter $out"
+        }
+        Else
+        {
+            throw "$out"
+        }
+        Set-Variable -Name "ok" -Value $true -Scope global
+    }
+    Catch
+    {
+        Write-Host "Error: $_"
+        Set-Variable -Name "ok" -Value $false -Scope global
+    }
 }
 
 runTests


### PR DESCRIPTION
Add error-prone test definitions invocation through python: overall run will fail in case of generation problem.

- [x] https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/22320/