### PR TITLE
Keep journal files for later forensic analysis

### DIFF
--- a/scripts/lib/tests.fish
+++ b/scripts/lib/tests.fish
@@ -222,8 +222,8 @@ function createReport
   echo $result >> testProtocol.txt
   and begin
     pushd $INNERWORKDIR
-    echo tar czvf "$INNERWORKDIR/ArangoDB/innerlogs.tar.gz" --exclude databases --exclude rocksdb --exclude journals tmp
-    eval $IONICE nice -n 10 tar czvf "$INNERWORKDIR/ArangoDB/innerlogs.tar.gz" --exclude databases --exclude rocksdb --exclude journals tmp
+    echo tar czvf "$INNERWORKDIR/ArangoDB/innerlogs.tar.gz" --exclude databases tmp
+    eval $IONICE nice -n 10 tar czvf "$INNERWORKDIR/ArangoDB/innerlogs.tar.gz" --exclude databases tmp
     popd
   end
   and begin


### PR DESCRIPTION
We found that in the collection of `innerlogs.tar.gz` the `journals`
folder of RocksDB is excluded. This cuts off the WALs of all instances,
which makes later forensic analysis of the data impossible, in
particular, if the runtime was short and the WAL has not yet been
written to sst files. This can happen in short runs for agents.

Therefore, it is better to keep the journals, as we also keep the rest
of the database directories.

This PR deletes the corresponding `--excludes`.
