### PR TITLE
add script to clear lingering resources on test machines

### DIFF
--- a/jenkins/helper/clear_machine.py
+++ b/jenkins/helper/clear_machine.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+import collections
+import sys
+import psutil
+# pylint: disable=bare-except disable=broad-except
+arango_processes = [
+    "arangod",
+    "arangodb",
+    "arangosync",
+    "arangosh",
+    "arangodbtests"
+]
+
+def print_tree(parent, tree, indent=''):
+    """ print the process tree """
+    try:
+        name = psutil.Process(parent).name()
+    except psutil.Error:
+        name = "?"
+    print(parent, name)
+    if parent not in tree:
+        return
+    children = tree[parent][:-1]
+    for child in children:
+        sys.stdout.write(indent + "|- ")
+        print_tree(child, tree, indent + "| ")
+    child = tree[parent][-1]
+    sys.stdout.write(indent + "`_ ")
+    print_tree(child, tree, indent + "  ")
+
+def get_and_kill_all_processes():
+    """fetch all possible running processes that we may have spawned"""
+    print("searching for leftover processes")
+    processes = psutil.process_iter()
+    interresting_processes = []
+    for process in processes:
+        try:
+            name = process.name()
+            for match_process in arango_processes:
+                if name.startswith(match_process):
+                    interresting_processes.append(process)
+        except:
+            pass
+
+    if len(interresting_processes) == 0:
+        print("system clean")
+    else:
+        for process in interresting_processes:
+            try:
+                print("will kill " + str(process))
+            except:
+                pass
+            try:
+                process.kill()
+            except Exception as ex:
+                print("failed to kill process!" + str(ex))
+
+def main():
+    # construct a dict where 'values' are all the processes
+    # having 'key' as their parent
+    tree = collections.defaultdict(list)
+    for process in psutil.process_iter():
+        try:
+            tree[process.ppid()].append(process.pid)
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            pass
+    # on systems supporting PID 0, PID 0's parent is usually 0
+    if 0 in tree and 0 in tree[0]:
+        tree[0].remove(0)
+    print_tree(min(tree), tree)
+    get_and_kill_all_processes()
+main()

--- a/jenkins/runCatchTestMac.fish
+++ b/jenkins/runCatchTestMac.fish
@@ -1,4 +1,7 @@
 #!/usr/bin/env fish
+
+python3 jenkins/helper/clear_machine.py
+
 source jenkins/helper/jenkins.fish
 
 cleanPrepareLockUpdateClear2

--- a/jenkins/runFullNightlyTestMac.fish
+++ b/jenkins/runFullNightlyTestMac.fish
@@ -1,4 +1,7 @@
 #!/usr/bin/env fish
+
+python3 jenkins/helper/clear_machine.py
+
 source jenkins/helper/jenkins.fish
 
 cleanPrepareLockUpdateClear

--- a/jenkins/runPRtestMac.fish
+++ b/jenkins/runPRtestMac.fish
@@ -1,4 +1,7 @@
 #!/usr/bin/env fish
+
+python3 jenkins/helper/clear_machine.py
+
 set -l date (date +%Y%m%d)
 set -l t1 (date +%s)
 set -l filename work/totalTimes.csv


### PR DESCRIPTION
processes may for some reason continue running and suck cpu resources. 
This script is intended to clean the machine and run it at the very beginning of the jenkins job:

```
jenkins@hw37-mac ~ % python3 ./clear_machine.py
saontueh
0 kernel_task
`_ 1 launchd
  |- 70 logd
  |- 71 UserEventAgent
  |- 74 uninstalld
  |- 75 fseventsd
  |- 76 mediaremoted
  |- 78 systemstats
  | `_ 639 systemstats
...
  |- 12008 bash
  | `_ 12027 arangosh
  |   `_ 12028 arangodbtests
  |- 12032 mdworker_shared
...
  |- 40090 arangosh
  |- 41449 bash
  | `_ 41468 arangosh
  |   `_ 41469 arangodbtests
  |- 42830 ssh-agent
  |- 44681 PerfPowerService
  |- 52424 bash
  | `_ 52443 arangosh
  |   `_ 52444 arangodbtests
  |- 53560 bash
  | `_ 53579 arangosh
  |   `_ 53580 arangodbtests
  |- 84642 bash
  | `_ 84661 arangosh
  |   `_ 84662 arangodbtests
searching for leftover processes
will kill psutil.Process(pid=12027, name='arangosh', status='running', started='2022-07-18 10:31:14')
will kill psutil.Process(pid=12028, name='arangodbtests', status='running', started='2022-07-18 10:31:15')
will kill psutil.Process(pid=12028, name='arangodbtests', status='running', started='2022-07-18 10:31:15')
will kill psutil.Process(pid=12028, name='arangodbtests', status='running', started='2022-07-18 10:31:15')
will kill psutil.Process(pid=40090, name='arangosh', status='running', started='2022-09-03 21:51:43')
will kill psutil.Process(pid=41468, name='arangosh', status='running', started='2022-07-14 16:38:43')
will kill psutil.Process(pid=41469, name='arangodbtests', status='running', started='2022-07-14 16:38:44')
will kill psutil.Process(pid=41469, name='arangodbtests', status='running', started='2022-07-14 16:38:44')
will kill psutil.Process(pid=41469, name='arangodbtests', status='running', started='2022-07-14 16:38:44')
will kill psutil.Process(pid=52443, name='arangosh', status='running', started='2022-07-11 13:35:04')
will kill psutil.Process(pid=52444, name='arangodbtests', status='running', started='2022-07-11 13:35:05')
will kill psutil.Process(pid=52444, name='arangodbtests', status='running', started='2022-07-11 13:35:05')
will kill psutil.Process(pid=52444, name='arangodbtests', status='running', started='2022-07-11 13:35:05')
will kill psutil.Process(pid=53579, name='arangosh', status='running', started='2022-08-31 19:45:11')
will kill psutil.Process(pid=53580, name='arangodbtests', status='running', started='2022-08-31 19:45:11')
will kill psutil.Process(pid=53580, name='arangodbtests', status='running', started='2022-08-31 19:45:11')
will kill psutil.Process(pid=53580, name='arangodbtests', status='running', started='2022-08-31 19:45:11')
will kill psutil.Process(pid=84661, name='arangosh', status='running', started='2022-07-13 11:00:14')
will kill psutil.Process(pid=84662, name='arangodbtests', status='running', started='2022-07-13 11:00:15')
will kill psutil.Process(pid=84662, name='arangodbtests', status='running', started='2022-07-13 11:00:15')
will kill psutil.Process(pid=84662, name='arangodbtests', status='running', started='2022-07-13 11:00:15')

```