### PR TITLE
Feature/cucoo python oskar

### DIFF
--- a/helper.fish
+++ b/helper.fish
@@ -1,5 +1,9 @@
 set -gx KEYNAME 115E1684
 
+if test "$IS_JENKINS" = "true"
+   python3 jenkins/helper/clear_machine.py
+end
+
 function lockDirectory
   # Now grab the lock ourselves:
   set -l pid (echo %self)

--- a/jenkins/helper/clear_machine.py
+++ b/jenkins/helper/clear_machine.py
@@ -36,6 +36,7 @@ def get_and_kill_all_processes():
     processes = psutil.process_iter(['pid', 'name', 'username'])
     interresting_processes = []
     pid = -1
+    print(os.environ)
     if 'SSH_AGENT_PID' in os.environ:
         pid = int(os.environ['SSH_AGENT_PID'])
         print("having agent PID: " + str(pid))

--- a/jenkins/helper/clear_machine.py
+++ b/jenkins/helper/clear_machine.py
@@ -37,16 +37,18 @@ def get_and_kill_all_processes():
     pid = -1
     if 'SSH_AGENT_PID' in os.environ:
         pid = int(os.environ['SSH_AGENT_PID'])
+        print("having agent PID: " + str(pid))
     for process in processes:
         try:
             name = process.name()
+            print(f"{name} - {process.username()} {process.pid}"
             for match_process in arango_processes:
                 if name.startswith(match_process):
                     interresting_processes.append(process)
             if pid >= 0:
-                if (name == 'ssh-agent' and
-                    process.username() == 'jenkins' and
-                    process.pid != pid):
+                if (name.startswith('ssh-agent') and
+                    (process.username() == 'jenkins') and
+                    int(process.pid) != pid):
                     interresting_processes.append(process)
         except:
             pass

--- a/jenkins/helper/clear_machine.py
+++ b/jenkins/helper/clear_machine.py
@@ -44,7 +44,6 @@ def get_and_kill_all_processes():
                 break
     except:
         myself = None
-        pass
     # print(os.environ)
     if 'SSH_AGENT_PID' in os.environ:
         pid = int(os.environ['SSH_AGENT_PID'])

--- a/jenkins/helper/clear_machine.py
+++ b/jenkins/helper/clear_machine.py
@@ -47,11 +47,10 @@ def get_and_kill_all_processes():
             for match_process in arango_processes:
                 if name.startswith(match_process):
                     interresting_processes.append(process)
-            if pid >= 0:
-                if (name.startswith('ssh-agent') and
-                    (process.username() == 'jenkins') and
-                    int(process.pid) != pid):
-                    interresting_processes.append(process)
+            if (name.startswith('ssh-agent') and
+                (process.username() == 'jenkins') and
+                int(process.pid) != pid):
+                interresting_processes.append(process)
         except:
             pass
 

--- a/jenkins/helper/clear_machine.py
+++ b/jenkins/helper/clear_machine.py
@@ -32,7 +32,7 @@ def print_tree(parent, tree, indent=''):
 def get_and_kill_all_processes():
     """fetch all possible running processes that we may have spawned"""
     print("searching for leftover processes")
-    processes = psutil.process_iter()
+    processes = psutil.process_iter(['pid', 'name', 'username'])
     interresting_processes = []
     pid = -1
     if 'SSH_AGENT_PID' in os.environ:
@@ -45,7 +45,7 @@ def get_and_kill_all_processes():
                     interresting_processes.append(process)
             if pid >= 0:
                 if (name == 'ssh-agent' and
-                    process.user == 'jenkins' and
+                    process.username() == 'jenkins' and
                     process.pid != pid):
                     interresting_processes.append(process)
         except:

--- a/jenkins/helper/clear_machine.py
+++ b/jenkins/helper/clear_machine.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 import collections
+import os
 import sys
 import psutil
 # pylint: disable=bare-except disable=broad-except
@@ -33,11 +34,19 @@ def get_and_kill_all_processes():
     print("searching for leftover processes")
     processes = psutil.process_iter()
     interresting_processes = []
+    pid = -1
+    if 'SSH_AGENT_PID' in os.environ:
+        pid = int(os.environ['SSH_AGENT_PID'])
     for process in processes:
         try:
             name = process.name()
             for match_process in arango_processes:
                 if name.startswith(match_process):
+                    interresting_processes.append(process)
+            if pid >= 0:
+                if (name == 'ssh-agent' and
+                    process.user == 'jenkins' and
+                    process.pid != pid):
                     interresting_processes.append(process)
         except:
             pass

--- a/jenkins/helper/clear_machine.py
+++ b/jenkins/helper/clear_machine.py
@@ -39,10 +39,13 @@ def get_and_kill_all_processes():
     myself = psutil.Process(os.getpid())
     try:
         while True:
+            print(str(myself))
             myself = myself.parent()
             if myself.name().startswith("java"):
+                print(f"Found my parent java: {str(myself)}")
                 break
     except:
+        print("no parent java process found")
         myself = None
     # print(os.environ)
     if 'SSH_AGENT_PID' in os.environ:

--- a/jenkins/helper/clear_machine.py
+++ b/jenkins/helper/clear_machine.py
@@ -36,14 +36,14 @@ def get_and_kill_all_processes():
     processes = psutil.process_iter(['pid', 'name', 'username'])
     interresting_processes = []
     pid = -1
-    print(os.environ)
+    # print(os.environ)
     if 'SSH_AGENT_PID' in os.environ:
         pid = int(os.environ['SSH_AGENT_PID'])
         print("having agent PID: " + str(pid))
     for process in processes:
         try:
             name = process.name()
-            print(f"{name} - {process.username()} {process.pid}")
+            # print(f"{name} - {process.username()} {process.pid}")
             for match_process in arango_processes:
                 if name.startswith(match_process):
                     interresting_processes.append(process)

--- a/jenkins/helper/clear_machine.py
+++ b/jenkins/helper/clear_machine.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+""" aimns to purge all resources that are stray and hinder ci work by blocking resources """
 import collections
 import os
 import sys
@@ -41,7 +42,7 @@ def get_and_kill_all_processes():
     for process in processes:
         try:
             name = process.name()
-            print(f"{name} - {process.username()} {process.pid}"
+            print(f"{name} - {process.username()} {process.pid}")
             for match_process in arango_processes:
                 if name.startswith(match_process):
                     interresting_processes.append(process)
@@ -67,8 +68,10 @@ def get_and_kill_all_processes():
                 print("failed to kill process!" + str(ex))
 
 def main():
-    # construct a dict where 'values' are all the processes
-    # having 'key' as their parent
+    """
+    construct a dict where 'values' are all the processes
+    having 'key' as their parent
+    """
     tree = collections.defaultdict(list)
     for process in psutil.process_iter():
         try:

--- a/jenkins/helper/clear_machine.py
+++ b/jenkins/helper/clear_machine.py
@@ -36,6 +36,15 @@ def get_and_kill_all_processes():
     processes = psutil.process_iter(['pid', 'name', 'username'])
     interresting_processes = []
     pid = -1
+    myself = psutil.Process(os.getpid())
+    try:
+        while True:
+            myself = myself.parent()
+            if myself.name().startswith("java"):
+                break
+    except:
+        myself = None
+        pass
     # print(os.environ)
     if 'SSH_AGENT_PID' in os.environ:
         pid = int(os.environ['SSH_AGENT_PID'])
@@ -50,6 +59,9 @@ def get_and_kill_all_processes():
             if (name.startswith('ssh-agent') and
                 (process.username() == 'jenkins') and
                 int(process.pid) != pid):
+                interresting_processes.append(process)
+            if myself and name.startswith('java') and process.pid != myself.pid:
+                print(f"found a java process which is not my parent, adding to list: {str(process)}")
                 interresting_processes.append(process)
         except:
             pass

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -658,7 +658,7 @@ class TestingRunner():
         is_empty = len(files) == 0
         if not is_empty and move_files:
             core_dir = core_dir / 'coredumps'
-            core_dir.mkdir(parents=True, exists_ok=True)
+            core_dir.mkdir(parents=True, exist_ok=True)
             for one_file in files:
                 if one_file.exists():
                     try:

--- a/jenkins/runCatchTestMac.fish
+++ b/jenkins/runCatchTestMac.fish
@@ -1,7 +1,5 @@
 #!/usr/bin/env fish
 
-python3 jenkins/helper/clear_machine.py
-
 source jenkins/helper/jenkins.fish
 
 cleanPrepareLockUpdateClear2

--- a/jenkins/runFullNightlyTestMac.fish
+++ b/jenkins/runFullNightlyTestMac.fish
@@ -1,7 +1,5 @@
 #!/usr/bin/env fish
 
-python3 jenkins/helper/clear_machine.py
-
 source jenkins/helper/jenkins.fish
 
 cleanPrepareLockUpdateClear

--- a/jenkins/runPRtestMac.fish
+++ b/jenkins/runPRtestMac.fish
@@ -1,7 +1,5 @@
 #!/usr/bin/env fish
 
-python3 jenkins/helper/clear_machine.py
-
 set -l date (date +%Y%m%d)
 set -l t1 (date +%s)
 set -l filename work/totalTimes.csv


### PR DESCRIPTION
- any jenkins [linux|mac] run should kick the other chickens out of the nest.
- kill stray ssh-agents
- kill stray java instances
- testrunner: move coredumps out of public directories to avoid permission issues before creating the crashdump