### PR TITLE
Force reset branch to origin for Jenkins

### DIFF
--- a/scripts/switchBranches.fish
+++ b/scripts/switchBranches.fish
@@ -27,8 +27,7 @@ function checkoutRepo
     else
       git remote update origin
       git fetch --force --all
-      git pull
-      git reset --hard "$branch"
+      git reset --hard origin/"$branch"
     end
     and git clean -fdx
   else


### PR DESCRIPTION
Trying to fix an issue where force-pushing to branches plus caching on Jenkins workers leads to old versions being tested.