### PR TITLE
Feature/breathe faster on bigger machines

### DIFF
--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -456,6 +456,9 @@ def testing_runner(testing_instance, this, arangosh):
     this.summary = ret['error']
     if this.summary_file.exists():
         this.summary += this.summary_file.read_text()
+    else:
+        print(f'{this.name_enum} no testreport!')
+
     with arangosh.slot_lock:
         testing_instance.running_suites.remove(this.name_enum)
 
@@ -645,7 +648,10 @@ class TestingRunner():
                 sys.stdout.flush()
                 rapid_fire = 0
                 par = 1
-                while self.cfg.rapid_fire > rapid_fire and par > 0 and self.cfg.available_slots > used_slots:
+                while (self.cfg.rapid_fire > rapid_fire and
+                       self.cfg.available_slots > used_slots and
+                       len(self.scenarios) > start_offset and
+                       par > 0):
                     
                     par =  self.launch_next(start_offset, counter, last_started_count != -1)
                     rapid_fire += par

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -648,12 +648,13 @@ class TestingRunner():
                 while self.cfg.rapid_fire > rapid_fire and par > 0 and self.cfg.available_slots > used_slots:
                     par =  self.launch_next(start_offset, counter, last_started_count != -1)
                     rapid_fire += par
+                    if par > 0:
+                        counter += 1
+                        time.sleep(0.1)
                 if par > 0:
                     parallelity = par
                     last_started_count = sleep_count
-                    start_offset += 1
                     time.sleep(self.cfg.loop_sleep)
-                    counter += 1
                     self.print_active()
                 else:
                     if used_slots == 0 and start_offset >= len(self.scenarios):

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -370,8 +370,8 @@ class SiteConfig:
             self.no_threads = 6 # M1 only has 4 performance cores
             self.available_slots = 10
         if IS_WINDOWS:
-            self.max_load = 0.85
-            self.max_load1 = 3.5
+            self.max_load = self.no_threads * 0.5
+            self.max_load1 = self.no_threads * 0.6
         else:
             self.max_load = self.no_threads * 0.9
             self.max_load1 = self.no_threads * 0.95

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -371,7 +371,7 @@ class SiteConfig:
             self.available_slots = 10
         if IS_WINDOWS:
             self.max_load = 0.85
-            self.max_load1 = 0.75
+            self.max_load1 = 3.5
         else:
             self.max_load = self.no_threads * 0.9
             self.max_load1 = self.no_threads * 0.95

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -375,6 +375,11 @@ class SiteConfig:
         else:
             self.max_load = self.no_threads * 0.9
             self.max_load1 = self.no_threads * 0.95
+        # roughly increase 1 per ten cores
+        self.core_dozend = int(self.no_threads / 10)
+        if self.core_dozend == 0:
+            self.core_dozend = 1
+        self.loop_sleep = 8 / self.core_dozend
         self.overload = self.max_load * 1.4
         self.slots_to_parallelity_factor = self.max_load / self.available_slots
         if 'SAN' in os.environ and os.environ['SAN'] == 'On':
@@ -402,6 +407,7 @@ class SiteConfig:
  - current Disk I/O: {str(psutil.disk_io_counters())}
  - current Swap: {str(psutil.swap_memory())}
  - Starting {str(datetime.now())} soft deadline will be: {str(self.deadline)} hard deadline will be: {str(self.hard_deadline)}
+ - {self.core_dozend} / {self.loop_sleep} machine size / loop frequency
  """)
         self.cfgdir = base_source_dir / 'etc' / 'relative'
         self.bin_dir = bin_dir
@@ -641,7 +647,7 @@ class TestingRunner():
                     parallelity = par
                     last_started_count = sleep_count
                     start_offset += 1
-                    time.sleep(5)
+                    time.sleep(self.cfg.loop_sleep)
                     counter += 1
                     self.print_active()
                 else:
@@ -649,11 +655,11 @@ class TestingRunner():
                         print("done")
                         break
                     self.print_active()
-                    time.sleep(5)
+                    time.sleep(self.cfg.loop_sleep)
                     sleep_count += 1
             else:
                 self.print_active()
-                time.sleep(5)
+                time.sleep(self.cfg.loop_sleep)
                 sleep_count += 1
         self.deadline_reached = datetime.now() > self.cfg.deadline
         if self.deadline_reached:

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -376,10 +376,10 @@ class SiteConfig:
             self.max_load = self.no_threads * 0.9
             self.max_load1 = self.no_threads * 0.95
         # roughly increase 1 per ten cores
-        self.core_dozend = int(self.no_threads / 10)
+        self.core_dozend = round(self.no_threads / 10)
         if self.core_dozend == 0:
             self.core_dozend = 1
-        self.loop_sleep = 8 / self.core_dozend
+        self.loop_sleep = round(5 / self.core_dozend)
         self.overload = self.max_load * 1.4
         self.slots_to_parallelity_factor = self.max_load / self.available_slots
         if 'SAN' in os.environ and os.environ['SAN'] == 'On':

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -646,11 +646,13 @@ class TestingRunner():
                 rapid_fire = 0
                 par = 1
                 while self.cfg.rapid_fire > rapid_fire and par > 0 and self.cfg.available_slots > used_slots:
+                    
                     par =  self.launch_next(start_offset, counter, last_started_count != -1)
                     rapid_fire += par
                     if par > 0:
                         counter += 1
                         time.sleep(0.1)
+                        start_offset += 1
                 if par > 0:
                     parallelity = par
                     last_started_count = sleep_count

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -382,7 +382,7 @@ class SiteConfig:
         self.loop_sleep = round(5 / self.core_dozend)
         self.overload = self.max_load * 1.4
         self.slots_to_parallelity_factor = self.max_load / self.available_slots
-        self.rapidfire = round(self.slots / 10)
+        self.rapid_fire = round(self.available_slots / 10)
         if 'SAN' in os.environ and os.environ['SAN'] == 'On':
             self.available_slots /= 2
             self.timeout *= 1.5
@@ -403,7 +403,7 @@ class SiteConfig:
  - {self.slots_to_parallelity_factor} parallelity to load estimate factor
  - {self.overload} load1 threshhold for overload logging
  - {self.max_load} / {self.max_load1} configured maximum load 0 / 1
- - {self.available_slots} test slots {self.rapidfire} rapid fire slots
+ - {self.available_slots} test slots {self.rapid_fire} rapid fire slots
  - {str(TEMP)} - temporary directory
  - current Disk I/O: {str(psutil.disk_io_counters())}
  - current Swap: {str(psutil.swap_memory())}
@@ -643,11 +643,11 @@ class TestingRunner():
                   (sleep_count - last_started_count > parallelity)) ):
                 print(f"Launching more: {self.cfg.available_slots} > {used_slots} {counter} {last_started_count} ")
                 sys.stdout.flush()
-                rapidfire = 0
+                rapid_fire = 0
                 par = 1
-                while self.rapidfire > rapidfire and par > 0 and self.cfg.available_slots > used_slots:
+                while self.cfg.rapid_fire > rapid_fire and par > 0 and self.cfg.available_slots > used_slots:
                     par =  self.launch_next(start_offset, counter, last_started_count != -1)
-                    rapidfire += par
+                    rapid_fire += par
                 if par > 0:
                     parallelity = par
                     last_started_count = sleep_count


### PR DESCRIPTION
- we choose more realistic figures for load monitoring, which would throttle us.
- we already have the concept of `slots`, which should represent the capacity of the machine. Its currently calculated from the threads of the machine.
- `slots` of the tests are calculaded: singse server `1`, cluster `4` or `parallelity` from the tests config file. 
- we have a frequency at which we launch new jobs. This is here to not overrun machines with launching too many processes in parallel. This is controlled by a sleep time previously 5s, now `loop_sleep = round(5 / self.core_dozend)` 
- with all these changes the rampup of tests would still be to slow on larger machines, tests would exit quicker than new could belaunched.
=> 
- introduce `rapid_fire` which is derived to be 1/10th of the available `slots` of the machine. 
- rapid fire will now launch as many tests without any sleeps until the slots consumed by these tests sum up to be more than `rapid_fire` or machine load signalling overload.