### PR TITLE
Fix usage of encryption at rest for testing.js

### DIFF
--- a/helper.psm1
+++ b/helper.psm1
@@ -1,7 +1,6 @@
 $global:WORKDIR = $pwd
 $global:SCRIPTSDIR = Join-Path -Path $global:WORKDIR -ChildPath scripts
 
-$ENV:EncryptionAtRest = ""
 If (-Not($ENV:WORKSPACE))
 {
     $ENV:WORKSPACE = Join-Path -Path $global:WORKDIR -ChildPath work

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -280,7 +280,7 @@ class TestConfig():
         self.args = []
         for param in args:
             if param.startswith('$'):
-                paramname = param[1:].upper()
+                paramname = param[1:]
                 if paramname in os.environ:
                     self.args += os.environ[paramname].split(' ')
                 else:
@@ -325,8 +325,6 @@ class TestConfig():
             self.args += [ '--protocol', 'ssl']
         if 'http2' in flags:
             self.args += [ '--http2', 'true']
-        if 'encrypt' in flags:
-            self.args += [ '--encryptionAtRest', 'true']
 
     def __repr__(self):
         return f"""

--- a/scripts/lib/Utils.psm1
+++ b/scripts/lib/Utils.psm1
@@ -20,6 +20,15 @@ Function log([array]$log)
 # Test main control
 ################################################################################
 
+If ($ENTERPRISEEDITION -eq "On")
+{
+    $ENV:EncryptionAtRest = "--encryptionAtRest true"
+}
+Else
+{
+    $ENV:EncryptionAtRest = ""
+}
+
 Function runTests
 {
     If (Test-Path -PathType Container -Path $env:TMP)


### PR DESCRIPTION
- [x] https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/25377/

Should not see
```
Error: failed to expand environment variable: '$EncryptionAtRest' for 'shell_api_http'
Error: failed to expand environment variable: '$EncryptionAtRest' for 'shell_api_https'
Error: failed to expand environment variable: '$EncryptionAtRest' for 'shell_client_http'
Error: failed to expand environment variable: '$EncryptionAtRest' for 'shell_client_transaction_http'
```

Those should pick proper mode in Community and Enterprise (all platforms):
```
shell_api priority=500 single suffix=http -- $EncryptionAtRest
shell_api priority=500 single suffix=https -- $EncryptionAtRest --protocol ssl
shell_client priority=250 parallelity=2 single suffix=http -- $EncryptionAtRest
shell_client_transaction priority=750 single suffix=http -- $EncryptionAtRest
```