### PR TITLE
cleanup 'files', make sure 'files_unsorted' is an array

### DIFF
--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -776,6 +776,8 @@ class TestingRunner():
         if IS_MAC:
             move_files = True
             system_corefiles = list(Path('/cores').glob(core_pattern))
+            if system_corefiles is None:
+                system_corefiles = []
         files_unsorted = list(core_dir.glob(core_pattern))
         if files_unsorted is None:
             files_unsorted = []

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -776,21 +776,21 @@ class TestingRunner():
         if IS_MAC:
             move_files = True
             system_corefiles = list(Path('/cores').glob(core_pattern))
-        files_unsorted = list(core_dir.glob(core_pattern)) + system_corefiles
+        files_unsorted = list(core_dir.glob(core_pattern))
+        if files_unsorted is None:
+            files_unsorted = []
+        files_unsorted += system_corefiles
         if len(files_unsorted) == 0 or core_max_count <= 0:
             print(f'Coredumps are not collected: {str(len(files_unsorted))} coredumps found; coredumps max limit to collect is {str(core_max_count)}!')
             return
-        files = files_unsorted.copy().sort(key=get_file_size, reverse=True)
-        
-        for one_file in files:
+
+        for one_file in files_unsorted:
             if one_file.is_file():
                 size = (one_file.stat().st_size / (1024 * 1024))
                 if 0 < MAX_COREFILE_SIZE_MB and MAX_COREFILE_SIZE_MB < size:
                     print(f'deleting coredump {str(one_file)} its too big: {str(size)}')
-                    files.remove(one_file)
                     files_unsorted.remove(one_file)
             else:
-                files.remove(one_file)
                 files_unsorted.remove(one_file)
 
         if len(files_unsorted) > core_max_count and core_max_count > 0:
@@ -805,7 +805,7 @@ class TestingRunner():
         if not is_empty and move_files:
             core_dir = core_dir / 'coredumps'
             core_dir.mkdir(parents=True, exist_ok=True)
-            for one_file in files:
+            for one_file in files_unsorted:
                 if one_file.exists():
                     try:
                         shutil.move(str(one_file.resolve()), str(core_dir.resolve()))


### PR DESCRIPTION
- `files` is unneeded, remove it.
- fix: 
```
00:10:36 'NoneType' object is not iterable
00:10:36 Traceback (most recent call last):
00:10:36   File "C:\Jenkins\workspace\arangodb-matrix-pr-windows\EDITION\enterprise\STORAGE_ENGINE\rocksdb\TEST_SUITE\single\limit\windows&&test&&gce&&!rta\jenkins\helper\test_launch_controller.py", line 990, in launch
00:10:36     runner.generate_crash_report()
00:10:36   File "C:\Jenkins\workspace\arangodb-matrix-pr-windows\EDITION\enterprise\STORAGE_ENGINE\rocksdb\TEST_SUITE\single\limit\windows&&test&&gce&&!rta\jenkins\helper\test_launch_controller.py", line 785, in generate_crash_report
00:10:36     for one_file in files:
00:10:36 TypeError: 'NoneType' object is not iterable
00:10:36 FAILED
```

https://jenkins.arangodb.biz/view/PR/job/arangodb-matrix-pr/25422/