### PR TITLE
implement socket counting for mac

### DIFF
--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -520,9 +520,12 @@ def get_socket_count():
         for proc in psutil.process_iter(['pid', 'name']):
             if proc.name() != 'arangod':
                 continue
-            for socket in psutil.Process(proc.pid).connections():
-                if socket.status in INTERESTING_SOCKETS:
-                    counter += 1
+            try:
+                for socket in psutil.Process(proc.pid).connections():
+                    if socket.status in INTERESTING_SOCKETS:
+                        counter += 1
+            except psutil.ZombieProcess:
+                pass
     else:
         for socket in psutil.net_connections(kind='inet'):
             if socket.status in INTERESTING_SOCKETS:

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -513,19 +513,19 @@ INTERESTING_SOCKETS = [
 
 def get_socket_count():
     """ get the number of sockets lingering destruction """
+    # pylint: disable=too-many-nested-blocks
     counter = 0
     if IS_MAC:
         # Mac would need root for all sockets, so we just look
         # for arangods and their ports, which works without.
         for proc in psutil.process_iter(['pid', 'name']):
-            if proc.name() != 'arangod':
-                continue
-            try:
-                for socket in psutil.Process(proc.pid).connections():
-                    if socket.status in INTERESTING_SOCKETS:
-                        counter += 1
-            except psutil.ZombieProcess:
-                pass
+            if proc.name() in ['arangod', 'arangosh']:
+                try:
+                    for socket in psutil.Process(proc.pid).connections():
+                        if socket.status in INTERESTING_SOCKETS:
+                            counter += 1
+                except psutil.ZombieProcess:
+                    pass
     else:
         for socket in psutil.net_connections(kind='inet'):
             if socket.status in INTERESTING_SOCKETS:

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -497,24 +497,36 @@ def testing_runner(testing_instance, this, arangosh):
             testing_instance.success = False
     testing_instance.done_job(this.parallelity)
 
+INTERESTING_SOCKETS = [
+    psutil.CONN_FIN_WAIT1,
+    psutil.CONN_FIN_WAIT2,
+    psutil.CONN_CLOSE_WAIT,
+    psutil.CONN_ESTABLISHED,
+    psutil.CONN_SYN_SENT,
+    psutil.CONN_SYN_RECV,
+    psutil.CONN_TIME_WAIT,
+    psutil.CONN_CLOSE,
+    psutil.CONN_LAST_ACK,
+    psutil.CONN_LISTEN,
+    psutil.CONN_CLOSING
+]
+
 def get_socket_count():
     """ get the number of sockets lingering destruction """
     counter = 0
-    for socket in psutil.net_connections(kind='inet'):
-        if socket.status in [
-                psutil.CONN_FIN_WAIT1,
-                psutil.CONN_FIN_WAIT2,
-                psutil.CONN_CLOSE_WAIT,
-                psutil.CONN_ESTABLISHED,
-                psutil.CONN_SYN_SENT,
-                psutil.CONN_SYN_RECV,
-                psutil.CONN_TIME_WAIT,
-                psutil.CONN_CLOSE,
-                psutil.CONN_LAST_ACK,
-                psutil.CONN_LISTEN,
-                psutil.CONN_CLOSING
-        ]:
-            counter += 1
+    if IS_MAC:
+        # Mac would need root for all sockets, so we just look
+        # for arangods and their ports, which works without.
+        for proc in psutil.process_iter(['pid', 'name']):
+            if proc.name() != 'arangod':
+                continue
+            for socket in psutil.Process(proc.pid).connections():
+                if socket.status in INTERESTING_SOCKETS:
+                    counter += 1
+    else:
+        for socket in psutil.net_connections(kind='inet'):
+            if socket.status in INTERESTING_SOCKETS:
+                counter += 1
     return counter
 
 class TestingRunner():


### PR DESCRIPTION
since on mac the `jenkins` user doesn't have access to the systems global used socket state list, but to each individual processes socket list, this PR:
- moves the list of socket-states into a global static array
- for mac iterates over any process, filter them for `arangod`s
- fetch the socket statistics for all interesting processes and sumarizes them.
Since ArangoDs should be the main interesting socket creater & user during CI runs, this should give us the socket count information in valuable precision as the global socket count.