### PR TITLE
Switch all sanitizers builds to clang

### DIFF
--- a/scripts/buildArangoDB3.fish
+++ b/scripts/buildArangoDB3.fish
@@ -63,13 +63,13 @@ end
 #end
 
 if test "$SAN" = "On"
+  set -xg CC_NAME clang
+  set -xg CXX_NAME clang++
   # Suppress leaks detection only during building
   set -gx SAN_OPTIONS "detect_leaks=0"
   set -l SANITIZERS "-fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize=leak"
   if test "$SAN_MODE" = "TSan"
     set SANITIZERS "-fsanitize=thread"
-    set -xg CC_NAME clang
-    set -xg CXX_NAME clang++
   end
   set -g FULLARGS $FULLARGS \
    -DUSE_JEMALLOC=Off \

--- a/scripts/buildArangoDB4.fish
+++ b/scripts/buildArangoDB4.fish
@@ -63,13 +63,13 @@ end
 #end
 
 if test "$SAN" = "On"
+  set -xg CC_NAME clang
+  set -xg CXX_NAME clang++
   # Suppress leaks detection only during building
   set -gx SAN_OPTIONS "detect_leaks=0"
   set -l SANITIZERS "-fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize=leak"
   if test "$SAN_MODE" = "TSan"
     set SANITIZERS "-fsanitize=thread"
-    set -xg CC_NAME clang
-    set -xg CXX_NAME clang++
   end
   set -g FULLARGS $FULLARGS \
    -DUSE_JEMALLOC=Off \

--- a/scripts/buildArangoDB5.fish
+++ b/scripts/buildArangoDB5.fish
@@ -64,13 +64,13 @@ end
 #end
 
 if test "$SAN" = "On"
+  set -xg CC_NAME clang
+  set -xg CXX_NAME clang++
   # Suppress leaks detection only during building
   set -gx SAN_OPTIONS "detect_leaks=0"
   set -l SANITIZERS "-fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize=leak"
   if test "$SAN_MODE" = "TSan"
     set SANITIZERS "-fsanitize=thread"
-    set -xg CC_NAME clang
-    set -xg CXX_NAME clang++
   end
   set -g FULLARGS $FULLARGS \
    -DUSE_JEMALLOC=Off \

--- a/scripts/buildArangoDB6.fish
+++ b/scripts/buildArangoDB6.fish
@@ -64,13 +64,13 @@ end
 #end
 
 if test "$SAN" = "On"
+  set -xg CC_NAME clang
+  set -xg CXX_NAME clang++
   # Suppress leaks detection only during building
   set -gx SAN_OPTIONS "detect_leaks=0"
   set -l SANITIZERS "-fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize=leak"
   if test "$SAN_MODE" = "TSan"
     set SANITIZERS "-fsanitize=thread"
-    set -xg CC_NAME clang
-    set -xg CXX_NAME clang++
   end
   set -g FULLARGS $FULLARGS \
    -DUSE_JEMALLOC=Off \


### PR DESCRIPTION
After [found](https://arangodb.slack.com/archives/C1PJT16QP/p1667582319115689) gcc-11.3 bug (after unintentional update from gcc-11.2 in Ubuntu 20.04 LTS) there was a proposal to switch all sanitizers builds (currently only TSan) to clang:
- 3.8 (clang-12): https://jenkins01.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/1405/
- 3.9 (clang-13): https://jenkins01.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/1406/
- 3.10 (clang-14): https://jenkins01.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/1407/
- devel (clang-14): https://jenkins01.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/1408/