### PR TITLE
macos may trip about exiting processes

### DIFF
--- a/jenkins/helper/socket_counter.py
+++ b/jenkins/helper/socket_counter.py
@@ -29,16 +29,19 @@ def get_socket_count():
     if IS_MAC:
         # Mac would need root for all sockets, so we just look
         # for arangods and their ports, which works without.
-        for proc in psutil.process_iter(['pid', 'name']):
-            if proc.name() in ['arangod', 'arangosh']:
-                try:
-                    for socket in psutil.Process(proc.pid).connections():
-                        if socket.status in INTERESTING_SOCKETS:
-                            counter += 1
-                except psutil.ZombieProcess:
-                    pass
-                except psutil.NoSuchProcess:
-                    pass
+        try:
+            for proc in psutil.process_iter(['pid', 'name']):
+                if proc.name() in ['arangod', 'arangosh']:
+                    try:
+                        for socket in psutil.Process(proc.pid).connections():
+                            if socket.status in INTERESTING_SOCKETS:
+                                counter += 1
+                    except psutil.ZombieProcess:
+                        pass
+                    except psutil.NoSuchProcess:
+                        pass
+        except ProcessLookupError:
+            pass
     else:
         for socket in psutil.net_connections(kind='inet'):
             if socket.status in INTERESTING_SOCKETS:


### PR DESCRIPTION
fix this incident: 
```
11:42:24 Launching more: 12 > 4 1 0 
11:42:24 process no longer exists (pid=92215, name='mdworker_shared')
11:42:24 Traceback (most recent call last):
11:42:24   File "/usr/local/lib/python3.10/site-packages/psutil/_psosx.py", line 343, in wrapper
11:42:24     return fun(self, *args, **kwargs)
11:42:24   File "/usr/local/lib/python3.10/site-packages/psutil/_psosx.py", line 401, in cmdline
11:42:24     return cext.proc_cmdline(self.pid)
11:42:24 ProcessLookupError: [Errno 3] assume no such process (originated from sysctl(KERN_PROCARGS2) -> EINVAL)
11:42:24 
11:42:24 During handling of the above exception, another exception occurred:
11:42:24 
11:42:24 Traceback (most recent call last):
11:42:24   File "/Users/jenkins/workspace/arangodb-ANY-mac-matrix.x86-64/3dd74758/jenkins/helper/launch_handler.py", line 36, in launch
11:42:24     runner.testing_runner()
11:42:24   File "/Users/jenkins/workspace/arangodb-ANY-mac-matrix.x86-64/3dd74758/jenkins/helper/testing_runner.py", line 269, in testing_runner
11:42:24     par =  self.launch_next(start_offset, counter, last_started_count != -1)
11:42:24   File "/Users/jenkins/workspace/arangodb-ANY-mac-matrix.x86-64/3dd74758/jenkins/helper/testing_runner.py", line 145, in launch_next
11:42:24     sock_count = get_socket_count()
11:42:24   File "/Users/jenkins/workspace/arangodb-ANY-mac-matrix.x86-64/3dd74758/jenkins/helper/socket_counter.py", line 33, in get_socket_count
11:42:24     if proc.name() in ['arangod', 'arangosh']:
11:42:24   File "/usr/local/lib/python3.10/site-packages/psutil/__init__.py", line 628, in name
11:42:24     cmdline = self.cmdline()
11:42:24   File "/usr/local/lib/python3.10/site-packages/psutil/__init__.py", line 681, in cmdline
11:42:24     return self._proc.cmdline()
11:42:24   File "/usr/local/lib/python3.10/site-packages/psutil/_psosx.py", line 348, in wrapper
11:42:24     raise NoSuchProcess(self.pid, self._name)
11:42:24 psutil.NoSuchProcess: process no longer exists (pid=92215, name='mdworker_shared')
```
by ignoring the exception and aborting the socket counting. 