### PR TITLE
QA-332: don't trip on files already existing

### DIFF
--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -72,6 +72,7 @@ if 'INNERWORKDIR' in os.environ:
 else:
     TEMP = TEMP / 'ArangoDB'
 if TEMP.exists():
+    # pylint: disable=broad-except
     try:
         shutil.rmtree(TEMP)
         TEMP.mkdir(parents=True)

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -77,7 +77,10 @@ if TEMP.exists():
         shutil.rmtree(TEMP)
         TEMP.mkdir(parents=True)
     except Exception as ex:
-        print(f"failed to clean temporary directory: {ex} - will continue anyways")
+        msg = f"failed to clean temporary directory: {ex} - won't launch tests!"
+        (get_workspace() / 'testfailures.txt').write_text(msg + '\n')
+        print(msg)
+        sys.exit(2)
 else:
     TEMP.mkdir(parents=True)
 os.environ['TMPDIR'] = str(TEMP)

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -71,7 +71,13 @@ if 'INNERWORKDIR' in os.environ:
     TEMP = TEMP / 'tmp'
 else:
     TEMP = TEMP / 'ArangoDB'
-if not TEMP.exists():
+if TEMP.exists():
+    try:
+        shutil.rmtree(TEMP)
+        TEMP.mkdir(parents=True)
+    except Exception as ex:
+        print(f"failed to clean temporary directory: {ex} - will continue anyways")
+else:
     TEMP.mkdir(parents=True)
 os.environ['TMPDIR'] = str(TEMP)
 os.environ['TEMP'] = str(TEMP)

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -453,7 +453,9 @@ class TestingRunner():
                         try:
                             shutil.move(str(subsubsubdir), str(subdir))
                         except shutil.Error as ex:
-                            print(f"failed to move file while cleaning up temporary files {ex}")
+                            msg = f"generate_test_report: failed to move file while cleaning up temporary files {ex}"
+                            self.append_report_txt('\n' + msg + '\n')
+                            print(msg)
                             clean_subdir = False
                     if clean_subdir:
                         subsubdir.rmdir()

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -448,9 +448,15 @@ class TestingRunner():
             for subsubdir in subdir.iterdir():
                 path_segment = subsubdir.parts[len(subsubdir.parts) - 1]
                 if path_segment.startswith('arangosh_'):
+                    clean_subdir = True
                     for subsubsubdir in subsubdir.iterdir():
-                        shutil.move(str(subsubsubdir), str(subdir))
-                    subsubdir.rmdir()
+                        try:
+                            shutil.move(str(subsubsubdir), str(subdir))
+                        except shutil.Error as ex:
+                            print(f"failed to move file while cleaning up temporary files {ex}")
+                            clean_subdir = False
+                    if clean_subdir:
+                        subsubdir.rmdir()
         print("Creating " + str(tarfile))
         sys.stdout.flush()
         try:

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -401,6 +401,8 @@ class TestingRunner():
                 if one_file.exists():
                     try:
                         shutil.move(str(one_file.resolve()), str(core_dir.resolve()))
+                    except shutil.Error as ex:
+                        print(f"failed to move file while cleaning up temporary files {ex}")
                     except PermissionError as ex:
                         print(f"won't move {str(one_file)} - not an owner! {str(ex)}")
                         self.append_report_txt(f"won't move {str(one_file)} - not an owner! {str(ex)}")

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -402,7 +402,9 @@ class TestingRunner():
                     try:
                         shutil.move(str(one_file.resolve()), str(core_dir.resolve()))
                     except shutil.Error as ex:
-                        print(f"failed to move file while cleaning up temporary files {ex}")
+                        msg = f"generate_crash_report: failed to move file while while gathering coredumps: {ex}"
+                        self.append_report_txt('\n' + msg + '\n')
+                        print(msg)
                     except PermissionError as ex:
                         print(f"won't move {str(one_file)} - not an owner! {str(ex)}")
                         self.append_report_txt(f"won't move {str(one_file)} - not an owner! {str(ex)}")
@@ -453,7 +455,7 @@ class TestingRunner():
                         try:
                             shutil.move(str(subsubsubdir), str(subdir))
                         except shutil.Error as ex:
-                            msg = f"generate_test_report: failed to move file while cleaning up temporary files {ex}"
+                            msg = f"generate_test_report: failed to move file while cleaning up temporary files: {ex}"
                             self.append_report_txt('\n' + msg + '\n')
                             print(msg)
                             clean_subdir = False


### PR DESCRIPTION
if we fail to flatten the directory structure, simply ignore and live with it:
```

10:32:11 flattening inner dir structure
10:32:11 Destination path '/work/tmp/server_permissions/7' already exists
10:32:11 Traceback (most recent call last):
10:32:11   File "/home/jenkins/workspace/arangodb-matrix-pr-linux.x86-64/96e8a9f9/jenkins/helper/launch_handler.py", line 40, in launch
10:32:11     runner.generate_test_report()
10:32:11   File "/home/jenkins/workspace/arangodb-matrix-pr-linux.x86-64/96e8a9f9/jenkins/helper/testing_runner.py", line 450, in generate_test_report
10:32:11     shutil.move(str(subsubsubdir), str(subdir))
10:32:11   File "/usr/lib/python3.10/shutil.py", line 813, in move
10:32:11     raise Error("Destination path '%s' already exists" % real_dst)
10:32:11 shutil.Error: Destination path '/work/tmp/server_permissions/7' already exists
10:32:11 killing dmesg 69
```
will now only be anounced but ignored. 