### PR TITLE
Simplify & fix coredump report generation

### DIFF
--- a/jenkins/helper/test_config.py
+++ b/jenkins/helper/test_config.py
@@ -119,7 +119,7 @@ class TestConfig():
         if self.crashed:
             resultstr = "Crash occured in"
         return """
-{1} {0.name} => {0.parallelity}, {0.priority}, {0.success} -- {2}""".format(
+{1} {0.name} => {0.delta_seconds}, {0.parallelity}, {0.priority}, {0.success} -- {2}""".format(
             self,
             resultstr,
             ' '.join(self.args))


### PR DESCRIPTION
- use uniq variable names with proper naming of their current meaning
- simplify flow using early exits
- simplify flow by allways creating a directory with the coredumps to archive (we would accidently zip the build directory)
- use shutil to cleanup remaining files