### PR TITLE
Feature/improve load printing

### DIFF
--- a/jenkins/helper/async_client.py
+++ b/jenkins/helper/async_client.py
@@ -169,7 +169,7 @@ def add_message_to_report(params, string, print_it = True, add_to_error = False)
             f"{oskar*count}\n{oskar}{datestr}{string}{' '*offset}{oskar}\n{oskar*count}\n"
     else:
         params['output'].write(bytearray(
-            f"{oskar*count}\n{oskar}{datestr}{string}{' '*offset}{oskar}\n{oskar*count}\n"
+            f"{oskar*count}\n{oskar}{datestr}{string}{' '*offset}{oskar}\n{oskar*count}\n",
             "utf-8"))
         params['output'].flush()
     sys.stdout.flush()

--- a/jenkins/helper/async_client.py
+++ b/jenkins/helper/async_client.py
@@ -156,15 +156,21 @@ def convert_result(result_array):
 
 def add_message_to_report(params, string, print_it = True, add_to_error = False):
     """ add a message from python to the report strings/files + print it """
+    oskar = 'OSKAR'
+    count = int(80 / len(oskar))
+    datestr = f'  {datetime.now()} - '
+    offset = 80 - (len(string) + len(datestr) + 2 * len(oskar))
     if print_it:
         print(string)
     if add_to_error:
         params['error'] += 'async_client.py: ' + string + '\n'
     if isinstance(params['output'], list):
-        params['output'] += f"{'v'*80}\n{datetime.now()}>>>{string}<<<\n{'^'*80}\n"
+        params['output'] += \
+            f"{oskar*count}\n{oskar}{datestr}{string}{' '*offset}{oskar}\n{oskar*count}\n"
     else:
         params['output'].write(bytearray(
-            f"{'v'*80}\n{datetime.now()}>>>{string}<<<\n{'^'*80}\n", "utf-8"))
+            f"{oskar*count}\n{oskar}{datestr}{string}{' '*offset}{oskar}\n{oskar*count}\n"
+            "utf-8"))
         params['output'].flush()
     sys.stdout.flush()
     return string + '\n'

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -196,5 +196,5 @@ class SiteConfig:
         """ estimate whether the system is overloaded """
         load = psutil.getloadavg()
         if load[0] > self.overload:
-            return f"HIGH SYSTEM LOAD! {load[0]:9.2f}"
+            return f"HIGH SYSTEM LOAD! {load[0]:9.2f} > {self.overload:9.2f} "
         return None

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -196,5 +196,5 @@ class SiteConfig:
         """ estimate whether the system is overloaded """
         load = psutil.getloadavg()
         if load[0] > self.overload:
-            return f"HIGH SYSTEM LOAD! {load[0]}"
+            return f"HIGH SYSTEM LOAD! {load[0]:9.2f}"
         return None


### PR DESCRIPTION
- reduce the load avg number to two positions after the decimal point
- print a frame of `OSKAR` around messages printed into the tests outputs, so its more clear what this is about and (if) easy grep it out

Sample output:
```
OSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAR
OSKAR  2022-12-08 15:28:35.923063 - HIGH SYSTEM LOAD! 25.64                OSKAR
OSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAR
```