### PR TITLE
disable docker cleanup for now

### DIFF
--- a/jenkins/helper/clear_machine.py
+++ b/jenkins/helper/clear_machine.py
@@ -234,6 +234,6 @@ def main():
         tree[0].remove(0)
     print_tree(min(tree), tree)
     get_and_kill_all_processes()
-    if IS_LINUX:
-        clean_docker_containers()
+    #if IS_LINUX:
+    #    clean_docker_containers()
 main()


### PR DESCRIPTION
the cleanup removes too much. since old containers rather pile up over months than days, disable it until a proper fix is in place to safe resources. 