### PR TITLE
Fix coverage runs

### DIFF
--- a/helper.fish
+++ b/helper.fish
@@ -94,6 +94,7 @@ end
 
 function single ; set -gx TESTSUITE single ; end
 function cluster ; set -gx TESTSUITE cluster ; end
+function both ; set -gx TESTSUITE both ; end
 function resilience ; set -gx TESTSUITE resilience ; end
 function catchtest ; set -gx TESTSUITE gtest ; end
 function gtest ; set -gx TESTSUITE gtest ; end
@@ -809,7 +810,8 @@ function buildTarGzPackageHelper
   and ln -s "$name-$v$arch" "$name-$os-$v$arch"
   and tar -c -z -f "$WORKDIR/work/$name-$os-$v$arch.tar.gz" -h --exclude "etc" --exclude "bin/README" --exclude "var" "$name-$os-$v$arch"
   and rm -rf "$name-$os-$v$arch"
-  set s $status
+  set s $
+  status
 
   if test "$s" -eq 0
     rm -rf "$name-client-$os-$v$arch"
@@ -1519,7 +1521,7 @@ function showConfig
   printf $fmt3 'SkipGrey'       $SKIPGREY      '(skipGrey/includeGrey)'
   printf $fmt3 'OnlyGrey'       $ONLYGREY      '(onlyGreyOn/onlyGreyOff)'
   printf $fmt3 'Storage engine' $STORAGEENGINE '(mmfiles/rocksdb)'
-  printf $fmt3 'Test suite'     $TESTSUITE     '(single/cluster/resilience/gtest)'
+  printf $fmt3 'Test suite'     $TESTSUITE     '(single/cluster/both/resilience/gtest)'
   printf $fmt2 'Log Levels'     (echo $LOG_LEVELS)
   echo
   echo 'Package Configuration'

--- a/helper.fish
+++ b/helper.fish
@@ -94,7 +94,7 @@ end
 
 function single ; set -gx TESTSUITE single ; end
 function cluster ; set -gx TESTSUITE cluster ; end
-function both ; set -gx TESTSUITE both ; end
+function single_cluster ; set -gx TESTSUITE single_cluster ; end
 function resilience ; set -gx TESTSUITE resilience ; end
 function catchtest ; set -gx TESTSUITE gtest ; end
 function gtest ; set -gx TESTSUITE gtest ; end
@@ -1520,7 +1520,7 @@ function showConfig
   printf $fmt3 'SkipGrey'       $SKIPGREY      '(skipGrey/includeGrey)'
   printf $fmt3 'OnlyGrey'       $ONLYGREY      '(onlyGreyOn/onlyGreyOff)'
   printf $fmt3 'Storage engine' $STORAGEENGINE '(mmfiles/rocksdb)'
-  printf $fmt3 'Test suite'     $TESTSUITE     '(single/cluster/both/resilience/gtest)'
+  printf $fmt3 'Test suite'     $TESTSUITE     '(single/cluster/single_cluster/resilience/gtest)'
   printf $fmt2 'Log Levels'     (echo $LOG_LEVELS)
   echo
   echo 'Package Configuration'

--- a/helper.fish
+++ b/helper.fish
@@ -1942,11 +1942,11 @@ function moveResultsToWorkspace
     # Used in jenkins test
     echo Moving reports and logs to $WORKSPACE ...
     if test -f $WORKDIR/work/test.log
-#if head -1 $WORKDIR/work/test.log | grep BAD > /dev/null; or test $WORKSPACE_LOGS = "all"
+      if head -1 $WORKDIR/work/test.log | grep BAD > /dev/null; or test $WORKSPACE_LOGS = "all"
         for f in $WORKDIR/work/testreport* ; echo "mv $f" ; mv $f $WORKSPACE ; end
-#      else
-#        for f in $WORKDIR/work/testreport* ; echo "rm $f" ; rm $f ; end
-#      end
+      else
+        for f in $WORKDIR/work/testreport* ; echo "rm $f" ; rm $f ; end
+      end
 
       echo "mv test.log"
       mv $WORKDIR/work/test.log $WORKSPACE

--- a/helper.fish
+++ b/helper.fish
@@ -1940,11 +1940,11 @@ function moveResultsToWorkspace
   if test ! -z "$WORKSPACE"
     # Used in jenkins test
     echo Moving reports and logs to $WORKSPACE ...
-    if test -f $WORKDIR/work/test.log
-      for f in $WORKDIR/work/testreport* ; echo "mv $f" ; mv $f $WORKSPACE ; end
-
-      echo "mv test.log"
-      mv $WORKDIR/work/test.log $WORKSPACE
+    if head -1 $WORKDIR/work/test.log | grep -i -e ^BAD -e ^CRASH > /dev/null; or test $WORKSPACE_LOGS = "all"
+        for f in $WORKDIR/work/testreport* ; echo "mv $f" ; mv $f $WORKSPACE ; end
+      else
+        for f in $WORKDIR/work/testreport* ; echo "rm $f" ; rm $f ; end
+      end
 
       if test -f $WORKDIR/work/testProtocol.txt
         echo "mv testProtocol.txt"

--- a/helper.fish
+++ b/helper.fish
@@ -1941,11 +1941,7 @@ function moveResultsToWorkspace
     # Used in jenkins test
     echo Moving reports and logs to $WORKSPACE ...
     if test -f $WORKDIR/work/test.log
-      if head -1 $WORKDIR/work/test.log | grep BAD > /dev/null; or test $WORKSPACE_LOGS = "all"
-        for f in $WORKDIR/work/testreport* ; echo "mv $f" ; mv $f $WORKSPACE ; end
-      else
-        for f in $WORKDIR/work/testreport* ; echo "rm $f" ; rm $f ; end
-      end
+      for f in $WORKDIR/work/testreport* ; echo "mv $f" ; mv $f $WORKSPACE ; end
 
       echo "mv test.log"
       mv $WORKDIR/work/test.log $WORKSPACE

--- a/helper.fish
+++ b/helper.fish
@@ -810,8 +810,7 @@ function buildTarGzPackageHelper
   and ln -s "$name-$v$arch" "$name-$os-$v$arch"
   and tar -c -z -f "$WORKDIR/work/$name-$os-$v$arch.tar.gz" -h --exclude "etc" --exclude "bin/README" --exclude "var" "$name-$os-$v$arch"
   and rm -rf "$name-$os-$v$arch"
-  set s $
-  status
+  set s $status
 
   if test "$s" -eq 0
     rm -rf "$name-client-$os-$v$arch"

--- a/helper.fish
+++ b/helper.fish
@@ -1940,11 +1940,15 @@ function moveResultsToWorkspace
   if test ! -z "$WORKSPACE"
     # Used in jenkins test
     echo Moving reports and logs to $WORKSPACE ...
-    if head -1 $WORKDIR/work/test.log | grep -i -e ^BAD -e ^CRASH > /dev/null; or test $WORKSPACE_LOGS = "all"
+    if test -f $WORKDIR/work/test.log
+      if head -1 $WORKDIR/work/test.log | grep BAD > /dev/null; or test $WORKSPACE_LOGS = "all"
         for f in $WORKDIR/work/testreport* ; echo "mv $f" ; mv $f $WORKSPACE ; end
       else
         for f in $WORKDIR/work/testreport* ; echo "rm $f" ; rm $f ; end
       end
+
+      echo "mv test.log"
+      mv $WORKDIR/work/test.log $WORKSPACE
 
       if test -f $WORKDIR/work/testProtocol.txt
         echo "mv testProtocol.txt"

--- a/helper.fish
+++ b/helper.fish
@@ -1941,11 +1941,11 @@ function moveResultsToWorkspace
     # Used in jenkins test
     echo Moving reports and logs to $WORKSPACE ...
     if test -f $WORKDIR/work/test.log
-      if head -1 $WORKDIR/work/test.log | grep BAD > /dev/null; or test $WORKSPACE_LOGS = "all"
+#if head -1 $WORKDIR/work/test.log | grep BAD > /dev/null; or test $WORKSPACE_LOGS = "all"
         for f in $WORKDIR/work/testreport* ; echo "mv $f" ; mv $f $WORKSPACE ; end
-      else
-        for f in $WORKDIR/work/testreport* ; echo "rm $f" ; rm $f ; end
-      end
+#      else
+#        for f in $WORKDIR/work/testreport* ; echo "rm $f" ; rm $f ; end
+#      end
 
       echo "mv test.log"
       mv $WORKDIR/work/test.log $WORKSPACE

--- a/jenkins/helper/asciiprint.py
+++ b/jenkins/helper/asciiprint.py
@@ -58,7 +58,7 @@ ANSI_ESCAPE = re.compile(
 
 def ascii_convert_str(the_str: str):
     """convert string to only be ascii without control sequences"""
-    return ANSI_ESCAPE.sub(rb"", the_str)
+    return ANSI_ESCAPE.sub("", the_str)
 
 
 def ascii_print(string):

--- a/jenkins/helper/launch_handler.py
+++ b/jenkins/helper/launch_handler.py
@@ -25,7 +25,7 @@ def launch(args, tests):
         dmesg_thread.start()
         time.sleep(3)
     for test in tests:
-        runner.register_test_func(args.cluster, test)
+        runner.register_test_func(test)
     runner.sort_by_priority()
     print(runner.scenarios)
     create_report = True

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -137,7 +137,7 @@ class SiteConfig:
         self.slots_to_parallelity_factor = self.max_load / self.available_slots
         self.rapid_fire = round(self.available_slots / 10)
         self.is_asan = 'SAN' in os.environ and os.environ['SAN'] == 'On'
-        self.is_gcov = 'GCOV' in os.environ and os.environ['GCOV'] == 'On'
+        self.is_gcov = 'COVERAGE' in os.environ and os.environ['COVERAGE'] == 'On'
         if self.is_asan or self.is_gcov:
             print(('SAN' if self.is_asan else 'GCOV') + 'enabled, reducing possible system capacity')
             self.rapid_fire = 1

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import os
 from pathlib import Path
 import platform
+import re
 import shutil
 import signal
 import sys
@@ -55,8 +56,9 @@ def get_workspace():
     #        return workdir
     return Path.cwd() / 'work'
 
+ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 for env in os.environ:
-    print(f'{env}={os.environ[env]}')
+    print(f"{env}={ansi_escape.sub('', os.environ[env])}")
 TEMP = Path("/tmp/")
 if 'TMP' in os.environ:
     TEMP = Path(os.environ['TMP'])

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -137,8 +137,9 @@ class SiteConfig:
         self.slots_to_parallelity_factor = self.max_load / self.available_slots
         self.rapid_fire = round(self.available_slots / 10)
         self.is_asan = 'SAN' in os.environ and os.environ['SAN'] == 'On'
-        if self.is_asan:
-            print('SAN enabled, reducing possible system capacity')
+        self.is_gcov = 'GCOV' in os.environ and os.environ['GCOV'] == 'On'
+        if self.is_asan or is_gcov:
+            print(('SAN' if self.is_asan else 'GCOV') + 'enabled, reducing possible system capacity')
             self.rapid_fire = 1
             self.available_slots /= 4
             #self.timeout *= 1.5

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -138,7 +138,7 @@ class SiteConfig:
         self.rapid_fire = round(self.available_slots / 10)
         self.is_asan = 'SAN' in os.environ and os.environ['SAN'] == 'On'
         self.is_gcov = 'GCOV' in os.environ and os.environ['GCOV'] == 'On'
-        if self.is_asan or is_gcov:
+        if self.is_asan or self.is_gcov:
             print(('SAN' if self.is_asan else 'GCOV') + 'enabled, reducing possible system capacity')
             self.rapid_fire = 1
             self.available_slots /= 4

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -137,17 +137,20 @@ class SiteConfig:
         self.slots_to_parallelity_factor = self.max_load / self.available_slots
         self.rapid_fire = round(self.available_slots / 10)
         self.is_asan = 'SAN' in os.environ and os.environ['SAN'] == 'On'
+        self.is_aulsan = self.is_asan and os.environ['SAN_MODE'] == 'AULSan'
         self.is_gcov = 'COVERAGE' in os.environ and os.environ['COVERAGE'] == 'On'
         san_gcov_msg = ""
         if self.is_asan or self.is_gcov:
             san_gcov_msg = ' - SAN '
-            if os.environ['SAN_MODE'] == 'AULSan':
+            slot_divisor = 4
+            if self.is_aulsan:
                 san_gcov_msg = ' - AUL-SAN '
             elif self.is_gcov:
                 san_gcov_msg = ' - GCOV'
+                slot_divisor = 3
             san_gcov_msg += ' enabled, reducing possible system capacity\n'
             self.rapid_fire = 1
-            self.available_slots /= 4
+            self.available_slots /= slot_divisor
             #self.timeout *= 1.5
             self.loop_sleep *= 2
             self.max_load /= 2

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -139,7 +139,7 @@ class SiteConfig:
         self.is_asan = 'SAN' in os.environ and os.environ['SAN'] == 'On'
         self.is_gcov = 'COVERAGE' in os.environ and os.environ['COVERAGE'] == 'On'
         if self.is_asan or self.is_gcov:
-            print(('SAN' if self.is_asan else 'GCOV') + 'enabled, reducing possible system capacity')
+            print(('SAN' if self.is_asan else 'GCOV') + ' enabled, reducing possible system capacity')
             self.rapid_fire = 1
             self.available_slots /= 4
             #self.timeout *= 1.5

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -138,15 +138,19 @@ class SiteConfig:
         self.rapid_fire = round(self.available_slots / 10)
         self.is_asan = 'SAN' in os.environ and os.environ['SAN'] == 'On'
         self.is_gcov = 'COVERAGE' in os.environ and os.environ['COVERAGE'] == 'On'
+        san_gcov_msg = ""
         if self.is_asan or self.is_gcov:
-            print(('SAN' if self.is_asan else 'GCOV') + ' enabled, reducing possible system capacity')
+            san_gcov_msg = ' - SAN '
+            if os.environ['SAN_MODE'] == 'AULSan':
+                san_gcov_msg = ' - AUL-SAN '
+            elif self.is_gcov:
+                san_gcov_msg = ' - GCOV'
+            san_gcov_msg += ' enabled, reducing possible system capacity\n'
             self.rapid_fire = 1
             self.available_slots /= 4
             #self.timeout *= 1.5
             self.loop_sleep *= 2
             self.max_load /= 2
-            if os.environ['SAN_MODE'] == 'AULSan':
-                print('Aulsan must reduce even more!')
         self.deadline = datetime.now() + timedelta(seconds=self.timeout)
         self.hard_deadline = datetime.now() + timedelta(seconds=self.timeout + 660)
         if definition_file.is_file():
@@ -178,7 +182,7 @@ class SiteConfig:
  - Starting {str(datetime.now())} soft deadline will be: {str(self.deadline)} hard deadline will be: {str(self.hard_deadline)}
  - {self.core_dozend} / {self.loop_sleep} machine size / loop frequency
  - {socket_count} number of currently active tcp sockets
- """)
+{san_gcov_msg}""")
         self.cfgdir = base_source_dir / 'etc' / 'relative'
         self.bin_dir = bin_dir
         self.base_path = base_source_dir

--- a/jenkins/helper/test_config.py
+++ b/jenkins/helper/test_config.py
@@ -115,9 +115,9 @@ class TestConfig():
         # pylint: disable=consider-using-f-string
         resultstr = "Good result in"
         if not self.success:
-            resultstr = "Bad result in"
+            resultstr = "BAD result in"
         if self.crashed:
-            resultstr = "Crash occured in"
+            resultstr = "BAD Crash occured in"
         return """
 {1} {0.name} => {0.delta_seconds}, {0.parallelity}, {0.priority}, {0.success} -- {2}""".format(
             self,

--- a/jenkins/helper/test_config.py
+++ b/jenkins/helper/test_config.py
@@ -115,9 +115,9 @@ class TestConfig():
         # pylint: disable=consider-using-f-string
         resultstr = "Good result in"
         if not self.success:
-            resultstr = "BAD result in"
+            resultstr = "Bad result in"
         if self.crashed:
-            resultstr = "BAD Crash occured in"
+            resultstr = "Crash occured in"
         return """
 {1} {0.name} => {0.delta_seconds}, {0.parallelity}, {0.priority}, {0.success} -- {2}""".format(
             self,

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -56,7 +56,7 @@ def filter_tests(args, tests):
         for one_filter in filters:
             filtered = filter(one_filter, filtered)
         return filtered
-    if args.both:
+    if args.single_cluster:
         res_sg = list(list_generator(False))
         for one in res_sg:
             one['prefix'] = "sg_"
@@ -120,7 +120,7 @@ def parse_arguments():
     parser.add_argument("--validate-only", help="validates the test definition file", action="store_true")
     parser.add_argument("--help-flags", help="prints information about available flags and exits", action="store_true")
     parser.add_argument("--cluster", help="output only cluster tests instead of single server", action="store_true")
-    parser.add_argument("--both", help="process cluster cluster and single tests", action="store_true")
+    parser.add_argument("--single_cluster", help="process cluster cluster and single tests", action="store_true")
     parser.add_argument("--full", help="output full test set", action="store_true")
     parser.add_argument("--gtest", help="only run gtest", action="store_true")
     parser.add_argument("--all", help="output all test, ignore other filters", action="store_true")

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -19,6 +19,8 @@ if sys.version_info[0] != 3:
 
 def filter_tests(args, tests):
     """ filter testcase by operations target Single/Cluster/full """
+    for one in tests:
+        one['prefix'] = ""
     if args.all:
         return tests
 
@@ -52,13 +54,19 @@ def filter_tests(args, tests):
 
         filtered = copy.deepcopy(tests)
         for one_filter in filters:
+            print('zzzzz')
+            
+            print(one_filter)
             filtered = filter(one_filter, filtered)
         return filtered
     if args.both:
-        args.suffix = "sg"
         res_sg = list(list_generator(False))
-        args.suffix = "cl"
+        for one in res_sg:
+            print(one)
+            one['prefix'] = "sg_"
         res_cl = list(list_generator(True))
+        for one in res_cl:
+            one['prefix'] = "cl_"
         return res_sg + res_cl
     else:
         return list(list_generator(args.cluster))
@@ -84,6 +92,7 @@ known_flags = {
 }
 
 known_parameter = {
+    "prefix": 'internal',
     "buckets": "number of buckets to use for this test",
     "suffix": "suffix that is appended to the tests folder name",
     "priority": "priority that controls execution order. Testsuites with lower priority are executed later",

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -55,7 +55,11 @@ def filter_tests(args, tests):
             filtered = filter(one_filter, filtered)
         return filtered
     if args.both:
-        return list(list_generator(True)) + list(list_generator(False))
+        args.suffix = "sg"
+        res_sg = list(list_generator(False))
+        args.suffix = "cl"
+        res_cl = list(list_generator(True))
+        return res_sg + res_cl
     else:
         return list(list_generator(args.cluster))
 

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -132,6 +132,7 @@ def parse_arguments():
     parser.add_argument("--cluster", help="output only cluster tests instead of single server", action="store_true")
     parser.add_argument("--single_cluster", help="process cluster cluster and single tests", action="store_true")
     parser.add_argument("--enterprise", help="add enterprise tests", action="store_true")
+    parser.add_argument("--no-enterprise", help="add enterprise tests", action="store_true")
     parser.add_argument("--full", help="output full test set", action="store_true")
     parser.add_argument("--gtest", help="only run gtest", action="store_true")
     parser.add_argument("--all", help="output all test, ignore other filters", action="store_true")

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -59,7 +59,6 @@ def filter_tests(args, tests):
     if args.both:
         res_sg = list(list_generator(False))
         for one in res_sg:
-            print(one)
             one['prefix'] = "sg_"
         res_cl = list(list_generator(True))
         for one in res_cl:

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -54,9 +54,6 @@ def filter_tests(args, tests):
 
         filtered = copy.deepcopy(tests)
         for one_filter in filters:
-            print('zzzzz')
-            
-            print(one_filter)
             filtered = filter(one_filter, filtered)
         return filtered
     if args.both:

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -39,6 +39,9 @@ def filter_tests(args, tests):
         if args.gtest:
             filters.append(lambda test: "gtest" ==  test["name"])
 
+        if not args.enterprise:
+            filters.append(lambda test: "enterprise" not in test["flags"])
+
         if IS_WINDOWS:
             filters.append(lambda test: "!windows" not in test["flags"])
 
@@ -121,6 +124,7 @@ def parse_arguments():
     parser.add_argument("--help-flags", help="prints information about available flags and exits", action="store_true")
     parser.add_argument("--cluster", help="output only cluster tests instead of single server", action="store_true")
     parser.add_argument("--single_cluster", help="process cluster cluster and single tests", action="store_true")
+    parser.add_argument("--enterprise", help="add enterprise tests", action="store_true")
     parser.add_argument("--full", help="output full test set", action="store_true")
     parser.add_argument("--gtest", help="only run gtest", action="store_true")
     parser.add_argument("--all", help="output all test, ignore other filters", action="store_true")

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -59,23 +59,24 @@ def filter_tests(args, tests):
         filtered = copy.deepcopy(tests)
         for one_filter in filters:
             filtered = filter(one_filter, filtered)
+        remaining_tests = list(filtered)
         if cluster:
             # after we filtered for cluster only tests, we now need to make sure
             # that tests are actually launched as cluster tests:
-            for one in filtered:
+            for one in remaining_tests:
                 if not 'cluster' in one['flags']:
                     one['flags'].append('cluster')
-        return filtered
+        return remaining_tests
 
     if args.single_cluster:
-        res_sg = list(list_generator(False))
+        res_sg = list_generator(False)
         for one in res_sg:
             one['prefix'] = "sg_"
-        res_cl = list(list_generator(True))
+        res_cl = list_generator(True)
         for one in res_cl:
             one['prefix'] = "cl_"
         return res_sg + res_cl
-    return list(list_generator(args.cluster))
+    return list_generator(args.cluster)
 
 formats = {
     "dump": generate_dump_output,

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -25,6 +25,7 @@ def filter_tests(args, tests):
         return tests
 
     def list_generator(cluster):
+        # pylint: disable=too-many-branches
         filters = []
         if cluster:
             filters.append(lambda test: "single" not in test["flags"])
@@ -58,7 +59,14 @@ def filter_tests(args, tests):
         filtered = copy.deepcopy(tests)
         for one_filter in filters:
             filtered = filter(one_filter, filtered)
+        if cluster:
+            # after we filtered for cluster only tests, we now need to make sure
+            # that tests are actually launched as cluster tests:
+            for one in filtered:
+                if not 'cluster' in one['flags']:
+                    one['flags'].append('cluster')
         return filtered
+
     if args.single_cluster:
         res_sg = list(list_generator(False))
         for one in res_sg:
@@ -67,8 +75,7 @@ def filter_tests(args, tests):
         for one in res_cl:
             one['prefix'] = "cl_"
         return res_sg + res_cl
-    else:
-        return list(list_generator(args.cluster))
+    return list(list_generator(args.cluster))
 
 formats = {
     "dump": generate_dump_output,

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -521,6 +521,10 @@ class TestingRunner():
         """ create the log file with the stati """
         logfile = get_workspace() / 'test.log'
         with open(logfile, "w", encoding="utf-8") as filep:
+            state = 'GOOD\n'
+            if not self.success or self.crashed:
+                state  = 'BAD\n'
+            filep.write(state)
             for one_scenario in self.scenarios:
                 filep.write(one_scenario.print_test_log_line())
 

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -550,7 +550,7 @@ class TestingRunner():
 </table>
 ''')
 
-    def register_test_func(self, cluster, test):
+    def register_test_func(self, test):
         """ print one test function """
         args = test["args"]
         params = test["params"]
@@ -561,18 +561,12 @@ class TestingRunner():
 
         if test["parallelity"] :
             parallelity = test["parallelity"]
-        if 'single' in test['flags'] and cluster:
-            return
-        if 'cluster' in test['flags'] and not cluster:
-            return
-        if cluster:
+        if 'cluster' in test['flags']:
             self.cluster = True
             if parallelity == 1:
                 parallelity = 4
             args += ['--cluster', 'true',
                      '--dumpAgencyOnError', 'true']
-        if "enterprise" in test["flags"]:
-            return
         if "ldap" in test["flags"] and not 'LDAPHOST' in os.environ:
             return
 

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -549,10 +549,12 @@ class TestingRunner():
 
     def register_test_func(self, cluster, test):
         """ print one test function """
+        print('santoehuasnoetuh')
+        print(test)
         args = test["args"]
         params = test["params"]
         suffix = params.get("suffix", "")
-        name = test["name"]
+        name = test['prefix'] + test["name"]
         if suffix:
             name += f"_{suffix}"
 

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -350,7 +350,7 @@ class TestingRunner():
         shutil.rmtree(str(self.cfg.bin_dir / 'tzdata'))
         needed = [
             'tzdata',
-            'icudtl.dat',
+            'icudtl',
             'fuertetest',
             'arangovpack',
             'arangobackup',

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -351,17 +351,26 @@ class TestingRunner():
         needed = [
             'tzdata',
             'icudtl.dat',
-            'arangod',
-            'arangosh',
-            'arangodump',
-            'arangorestore',
-            'arangoimport',
+            'fuertetest',
+            'arangovpack',
             'arangobackup',
-            'arangodbtests']
+            'arangosh',
+            'arangoexport',
+            'arangoinspect',
+            'arangoimport',
+            'arangoimp',
+            'arango-secure-installation',
+            'foxx-manager',
+            'arangorestore',
+            'arangobench',
+            'snowball',
+            'arangodbtests',
+            'arangod',
+            'arango-init-database',
+            'arangodump']
         for one_file in self.cfg.bin_dir.iterdir():
             if (one_file.suffix == '.lib' or
-                (one_file.stem not in needed) or
-                not one_file.is_symlink()):
+                (one_file.stem not in needed)):
                 print(f'Deleting {str(one_file)}')
                 one_file.unlink(missing_ok=True)
 

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -425,9 +425,8 @@ class TestingRunner():
             if one_file.exists():
                 zip_slot_array[count % zip_slots].append(one_file)
                 count += 1
-        print(zip_slot_array)
         zippers = []
-        print("coredump launching zipper sub processes")
+        print(f"coredump launching zipper sub processes {zip_slot_array}")
         for zip_slot in zip_slot_array:
             if len(zip_slot) > 0:
                 proc = Process(target=zipp_this, args=(zip_slot, core_zip_dir))

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -10,6 +10,8 @@ import signal
 import sys
 import time
 from threading  import Thread, Lock
+from multiprocessing import Process
+import zipfile
 
 import psutil
 
@@ -40,6 +42,17 @@ try:
     ZIPFORMAT="7zip"
 except ModuleNotFoundError:
     pass
+
+def zipp_this(filenames, target_dir):
+    """ worker function to zip one file a time in a subprocess """
+    # pylint: disable=consider-using-with
+    for corefile in filenames:
+        try:
+            print(f'zipping {corefile}')
+            zipfile.ZipFile(str(target_dir / (corefile.name + '.xz')),
+                            mode='w', compression=zipfile.ZIP_LZMA).write(str(corefile))
+        except Exception as exc:
+            print(f'skipping {corefile} since {exc}')
 
 def testing_runner(testing_instance, this, arangosh):
     """ operate one makedata instance """
@@ -336,6 +349,8 @@ class TestingRunner():
         """ delete all files not needed for the crashreport binaries """
         shutil.rmtree(str(self.cfg.bin_dir / 'tzdata'))
         needed = [
+            'tzdata',
+            'icudtl.dat',
             'arangod',
             'arangosh',
             'arangodump',
@@ -345,7 +360,8 @@ class TestingRunner():
             'arangodbtests']
         for one_file in self.cfg.bin_dir.iterdir():
             if (one_file.suffix == '.lib' or
-                (one_file.stem not in needed) ):
+                (one_file.stem not in needed) or
+                not one_file.is_symlink()):
                 print(f'Deleting {str(one_file)}')
                 one_file.unlink(missing_ok=True)
 
@@ -382,56 +398,46 @@ class TestingRunner():
             print(f'Coredumps are not collected: {str(len(core_files_list))} coredumps found; coredumps max limit to collect is {str(core_max_count)}!')
             return
 
-        for one_file in core_files_list:
-            if one_file.is_file():
-                size = (one_file.stat().st_size / (1024 * 1024))
-                if 0 < MAX_COREFILE_SIZE_MB and MAX_COREFILE_SIZE_MB < size:
-                    print(f'deleting coredump {str(one_file)} its too big: {str(size)}')
-                    one_file.unlink(missing_ok=True)
-                    core_files_list.remove(one_file)
-            else:
-                print(f"removing file from list {str(one_file)}")
-                core_files_list.remove(one_file)
-
-        if len(core_files_list) > core_max_count and core_max_count > 0:
-            count = 0
-            for one_crash_file in core_files_list:
-                count += 1
-                if count > core_max_count:
-                    print(f'{core_max_count} reached. will not archive {one_crash_file}')
-                    one_crash_file.unlink(missing_ok=True)
-                    core_files_list.remove(one_crash_file)
-
-        if len(core_files_list) == 0:
-            return
-        self.crashed = True
-
         core_zip_dir = get_workspace() / 'coredumps'
         core_zip_dir.mkdir(parents=True, exist_ok=True)
+        zip_slots = psutil.cpu_count(logical=False)
+        count = 0
+        zip_slot_array = []
+        for _ in range(zip_slots):
+            zip_slot_array.append([])
         for one_file in core_files_list:
             if one_file.exists():
-                try:
-                    shutil.move(str(one_file.resolve()), str(core_zip_dir.resolve()))
-                except shutil.Error as ex:
-                    msg = f"generate_crash_report: failed to move file while while gathering coredumps: {ex}"
-                    self.append_report_txt('\n' + msg + '\n')
-                    print(msg)
-                except PermissionError as ex:
-                    print(f"won't move {str(one_file)} - not an owner! {str(ex)}")
-                    self.append_report_txt(f"won't move {str(one_file)} - not an owner! {str(ex)}")
+                zip_slot_array[count % zip_slots].append(one_file)
+                count += 1
+        print(zip_slot_array)
+        zippers = []
+        print("coredump launching zipper sub processes")
+        for zip_slot in zip_slot_array:
+            if len(zip_slot) > 0:
+                proc = Process(target=zipp_this, args=(zip_slot, core_zip_dir))
+                proc.start()
+                zippers.append(proc)
+        for zipper in zippers:
+            zipper.join()
+        print("compressing files done")
+
+        for one_file in core_files_list:
+            if one_file.is_file():
+                one_file.unlink(missing_ok=True)
 
         crash_report_file = get_workspace() / datetime.now(tz=None).strftime(f"crashreport-{self.cfg.datetime_format}")
         print(f"creating crashreport: {str(crash_report_file)} with {str(core_files_list)}")
         sys.stdout.flush()
         try:
             shutil.make_archive(str(crash_report_file),
-                                ZIPFORMAT,
+                                'tar',
                                 (core_zip_dir / '..').resolve(),
                                 core_zip_dir.name,
                                 True)
         except Exception as ex:
             print("Failed to create binaries zip: " + str(ex))
             self.append_report_txt("Failed to create binaries zip: " + str(ex))
+
         self.cleanup_unneeded_binary_files()
         binary_report_file = get_workspace() / datetime.now(tz=None).strftime(f"binaries-{self.cfg.datetime_format}")
         print("creating crashreport binary support zip: " + str(binary_report_file))

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -549,8 +549,6 @@ class TestingRunner():
 
     def register_test_func(self, cluster, test):
         """ print one test function """
-        print('santoehuasnoetuh')
-        print(test)
         args = test["args"]
         params = test["params"]
         suffix = params.get("suffix", "")

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -18,6 +18,7 @@ and begin
   if test -d $WORKDIR/work/gcov ; mv $WORKDIR/work/gcov $WORKDIR/work/gcov.old ; end
 
   rocksdb
+  set -e GCOV On
   single     ; oskarFull --isAsan true --sanitizer true ; or set s $status
   moveResultsToWorkspace
   setupTmp

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -18,7 +18,6 @@ and begin
   if test -d $WORKDIR/work/gcov ; mv $WORKDIR/work/gcov $WORKDIR/work/gcov.old ; end
 
   rocksdb
-  set GCOV On
   single     ; oskarFull --isAsan true --sanitizer true ; or set s $status
   moveResultsToWorkspace
   setupTmp

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -12,13 +12,13 @@ and skipGrey
 and switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
 and set -gx NOSTRIP 1
 and showConfig
-# and buildStaticArangoDB -DUSE_FAILURE_TESTS=On -DDEBUG_SYNC_REPLICATION=On
+and buildStaticArangoDB -DUSE_FAILURE_TESTS=On -DDEBUG_SYNC_REPLICATION=On
 and begin
   rm -rf $WORKDIR/work/gcov.old
   if test -d $WORKDIR/work/gcov ; mv $WORKDIR/work/gcov $WORKDIR/work/gcov.old ; end
 
   rocksdb
-  # both     ; oskarFull --isAsan true --sanitizer true ; or set s $status
+  both     ; oskarFull --isAsan true --sanitizer true ; or set s $status
   if test "$s" -eq 1
      set exitcode 5
   end

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -21,8 +21,8 @@ and begin
   set -l TMPDIR_O "$TMPDIR"
   set -l TMPDIR_SG "$TMPDIR/sg"
   set -l TMPDIR_CL "$TMPDIR/cl"
-  if test -d $TMPDIR_SG; rm -rf $TMPDIR_SG; end
-  if test -d $TMPDIR_CL; rm -rf $TMPDIR_CL; end
+  if test -d $TMPDIR_SG ; rm -rf $TMPDIR_SG ; end
+  if test -d $TMPDIR_CL ; rm -rf $TMPDIR_CL ; end
   mkdir $TMPDIR_SG
   mkdir $TMPDIR_CL
   set TMPDIR $TMPDIR_SG

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -18,7 +18,7 @@ and begin
   if test -d $WORKDIR/work/gcov ; mv $WORKDIR/work/gcov $WORKDIR/work/gcov.old ; end
 
   rocksdb
-  both     ; oskarFull --isAsan true --sanitizer true ; or set s $status
+  single_cluster     ; oskarFull --isAsan true --sanitizer true ; or set s $status
   if test "$s" -eq 1
      set exitcode 5
   end

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -2,7 +2,7 @@
 source jenkins/helper/jenkins.fish
 
 set s 0
-set exticode 0
+set exitcode 0
 cleanPrepareLockUpdateClear
 and enterprise
 and maintainerOn
@@ -22,7 +22,7 @@ and begin
   echo "S: $s"
   echo $status
   if test "$s" -eq 1
-     set exticode 5
+     set exitcode 5
   end
   collectCoverage
 end

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -24,7 +24,6 @@ and begin
   if test "$s" -eq 1
      set exticode 5
   end
-set exticode
   collectCoverage
 end
 or set exitcode $status

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -23,7 +23,7 @@ and begin
   cluster    ; oskarFull --isAsan true --sanitizer true ; or set s $status
   echo "S: $s"
   echo $status
-  if test $status = 0
+  if test $status -eq 0
      collectCoverage
      or set s $status
   end

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -18,7 +18,7 @@ and begin
   if test -d $WORKDIR/work/gcov ; mv $WORKDIR/work/gcov $WORKDIR/work/gcov.old ; end
 
   rocksdb
-  set -e GCOV On
+  set GCOV On
   single     ; oskarFull --isAsan true --sanitizer true ; or set s $status
   moveResultsToWorkspace
   setupTmp

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -30,4 +30,4 @@ or set exitcode $status
 
 cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory
 echo "exiting $exitcode"
-exit exitcode
+exit $exitcode

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -2,7 +2,7 @@
 source jenkins/helper/jenkins.fish
 
 set s 0
-
+set exticode 0
 cleanPrepareLockUpdateClear
 and enterprise
 and maintainerOn
@@ -21,12 +21,14 @@ and begin
   both     ; oskarFull --isAsan true --sanitizer true ; or set s $status
   echo "S: $s"
   echo $status
-  if test $status -eq 0
-     collectCoverage
-     or set s $status
+  if test "$s" -eq 1
+     set exticode 5
   end
+set exticode
+  collectCoverage
 end
-or set s $status
+or set exitcode $status
 
-cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory 
-exit $s
+cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory
+echo "exiting $exitcode"
+exit exitcode

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -27,10 +27,12 @@ and begin
   mkdir $TMPDIR_CL
   set TMPDIR $TMPDIR_SG
   single     ; oskarFull --isAsan true --sanitizer true ; or set s $status
+  echo "S: $s"
   set TMPDIR $TMPDIR_CL
   cluster    ; oskarFull --isAsan true --sanitizer true ; or set s $status
+  echo "S: $s"
   set TMPDIR $TMPDIR_O
-
+  echo $status
   if test $status = 0
      collectCoverage
      or set s $status

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -12,13 +12,13 @@ and skipGrey
 and switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
 and set -gx NOSTRIP 1
 and showConfig
-and buildStaticArangoDB -DUSE_FAILURE_TESTS=On -DDEBUG_SYNC_REPLICATION=On
+# and buildStaticArangoDB -DUSE_FAILURE_TESTS=On -DDEBUG_SYNC_REPLICATION=On
 and begin
   rm -rf $WORKDIR/work/gcov.old
   if test -d $WORKDIR/work/gcov ; mv $WORKDIR/work/gcov $WORKDIR/work/gcov.old ; end
 
   rocksdb
-  both     ; oskarFull --isAsan true --sanitizer true ; or set s $status
+  # both     ; oskarFull --isAsan true --sanitizer true ; or set s $status
   if test "$s" -eq 1
      set exitcode 5
   end

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -18,20 +18,11 @@ and begin
   if test -d $WORKDIR/work/gcov ; mv $WORKDIR/work/gcov $WORKDIR/work/gcov.old ; end
 
   rocksdb
-  set -l TMPDIR_O "$TMPDIR"
-  set -l TMPDIR_SG "$TMPDIR/sg"
-  set -l TMPDIR_CL "$TMPDIR/cl"
-  if test -d $TMPDIR_SG ; rm -rf $TMPDIR_SG ; end
-  if test -d $TMPDIR_CL ; rm -rf $TMPDIR_CL ; end
-  mkdir $TMPDIR_SG
-  mkdir $TMPDIR_CL
-  set TMPDIR $TMPDIR_SG
   single     ; oskarFull --isAsan true --sanitizer true ; or set s $status
-  echo "S: $s"
-  set TMPDIR $TMPDIR_CL
+  moveResultsToWorkspace
+  setupTmp
   cluster    ; oskarFull --isAsan true --sanitizer true ; or set s $status
   echo "S: $s"
-  set TMPDIR $TMPDIR_O
   echo $status
   if test $status = 0
      collectCoverage

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -9,6 +9,7 @@ and maintainerOn
 and sanOff
 and coverageOn
 and skipGrey
+and single_cluster
 and switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
 and set -gx NOSTRIP 1
 and showConfig
@@ -17,8 +18,7 @@ and begin
   rm -rf $WORKDIR/work/gcov.old
   if test -d $WORKDIR/work/gcov ; mv $WORKDIR/work/gcov $WORKDIR/work/gcov.old ; end
 
-  rocksdb
-  single_cluster     ; oskarFull --isAsan true --sanitizer true ; or set s $status
+  oskarFull --isAsan true --sanitizer true ; or set s $status
   if test "$s" -eq 1
      set exitcode 5
   end

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -19,8 +19,6 @@ and begin
 
   rocksdb
   both     ; oskarFull --isAsan true --sanitizer true ; or set s $status
-  echo "S: $s"
-  echo $status
   if test "$s" -eq 1
      set exitcode 5
   end

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -18,9 +18,7 @@ and begin
   if test -d $WORKDIR/work/gcov ; mv $WORKDIR/work/gcov $WORKDIR/work/gcov.old ; end
 
   rocksdb
-  single     ; oskarFull --isAsan true --sanitizer true ; or set s $status
-  moveResultsToWorkspace
-  cluster    ; oskarFull --isAsan true --sanitizer true ; or set s $status
+  both     ; oskarFull --isAsan true --sanitizer true ; or set s $status
   echo "S: $s"
   echo $status
   if test $status -eq 0

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -21,8 +21,10 @@ and begin
   single     ; oskarFull --isAsan true --sanitizer true ; or set s $status
   cluster    ; oskarFull --isAsan true --sanitizer true ; or set s $status
 
-  collectCoverage
-  or set s $status
+  if test $status = 0
+     collectCoverage
+     or set s $status
+  end
 end
 or set s $status
 

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -18,8 +18,18 @@ and begin
   if test -d $WORKDIR/work/gcov ; mv $WORKDIR/work/gcov $WORKDIR/work/gcov.old ; end
 
   rocksdb
+  set -l TMPDIR_O "$TMPDIR"
+  set -l TMPDIR_SG "$TMPDIR/sg"
+  set -l TMPDIR_CL "$TMPDIR/cl"
+  if test -d $TMPDIR_SG; rm -rf $TMPDIR_SG; end
+  if test -d $TMPDIR_CL; rm -rf $TMPDIR_CL; end
+  mkdir $TMPDIR_SG
+  mkdir $TMPDIR_CL
+  set TMPDIR $TMPDIR_SG
   single     ; oskarFull --isAsan true --sanitizer true ; or set s $status
+  set TMPDIR $TMPDIR_CL
   cluster    ; oskarFull --isAsan true --sanitizer true ; or set s $status
+  set TMPDIR $TMPDIR_O
 
   if test $status = 0
      collectCoverage

--- a/jenkins/runCoverageRocksDB.fish
+++ b/jenkins/runCoverageRocksDB.fish
@@ -20,7 +20,6 @@ and begin
   rocksdb
   single     ; oskarFull --isAsan true --sanitizer true ; or set s $status
   moveResultsToWorkspace
-  setupTmp
   cluster    ; oskarFull --isAsan true --sanitizer true ; or set s $status
   echo "S: $s"
   echo $status

--- a/scripts/coverage.fish
+++ b/scripts/coverage.fish
@@ -41,6 +41,7 @@ and tar x -f /tmp/gcno.tar -C /work/combined/result
 and rm -rf coverage
 and mkdir coverage
 and mkdir coverage/enterprise
+and ln -s /work/ArangoDB/3rdParty/jemalloc/v*/include /work/ArangoDB/include
 and gcovr --exclude-throw-branches --root /work/ArangoDB \
         -x \
         -e /work/ArangoDB/build \
@@ -64,4 +65,8 @@ and for d in lib arangosh client-tools arangod enterprise/Enterprise
   	echo "cp -a /work/ArangoDB/$d coverage/$d"
   	cp -a /work/ArangoDB/$d coverage/$d
   end
+and if test -d /work/ArangoDB/enterprise/tests
+        mkdir -p coverage/enterprise/tests
+        cp -a /work/ArangoDB/enterprise/tests coverage/enterprise/tests
+    end
 end

--- a/scripts/coverage.fish
+++ b/scripts/coverage.fish
@@ -57,6 +57,7 @@ and gcovr --exclude-throw-branches --root /work/ArangoDB \
 and cat coverage/coverage.xml \
       | sed -e "s:filename=\":filename=\"./coverage/:g" \
       > coverage/coverage.xml.tmp
+and mv coverage/coverage.xml coverage/coverage.org.xml
 and mv coverage/coverage.xml.tmp coverage/coverage.xml
 and for d in lib arangosh client-tools arangod enterprise/Enterprise
   if test -d /work/ArangoDB/$d

--- a/scripts/coverage.fish
+++ b/scripts/coverage.fish
@@ -44,7 +44,10 @@ and mkdir coverage/enterprise
 and gcovr --exclude-throw-branches --root /work/ArangoDB \
         -x \
         -e /work/ArangoDB/build \
+        -e /work/ArangoDB/build/3rdParty/libunwind/v* \
+        -e /work/ArangoDB/build/3rdParty/libunwind/v*/src/ \
         -e /work/ArangoDB/3rdParty \
+        -e /work/ArangoDB/3rdParty/jemalloc/v*/
         -e /work/ArangoDB/usr/ \
         -e /work/ArangoDB/tests \
         -e include/jemalloc/internal \

--- a/scripts/coverage.fish
+++ b/scripts/coverage.fish
@@ -66,7 +66,7 @@ and for d in lib arangosh client-tools arangod enterprise/Enterprise
   	cp -a /work/ArangoDB/$d coverage/$d
   end
 and if test -d /work/ArangoDB/enterprise/tests
-        mkdir -p coverage/enterprise/tests
+        echo "cp -a /work/ArangoDB/enterprise/tests coverage/enterprise/tests"
         cp -a /work/ArangoDB/enterprise/tests coverage/enterprise/tests
     end
 end

--- a/scripts/coverage.fish
+++ b/scripts/coverage.fish
@@ -47,10 +47,10 @@ and gcovr --exclude-throw-branches --root /work/ArangoDB \
         -e /work/ArangoDB/build/3rdParty/libunwind/v* \
         -e /work/ArangoDB/build/3rdParty/libunwind/v*/src/ \
         -e /work/ArangoDB/3rdParty \
-        -e /work/ArangoDB/3rdParty/jemalloc/v*/
+        -e /work/ArangoDB/3rdParty/jemalloc/v*/ \
         -e /work/ArangoDB/usr/ \
         -e /work/ArangoDB/tests \
-        -e include/jemalloc/internal \
+        -e /work/ArangoDB/arangod/Aql \
         -o coverage/coverage.xml \
         --exclude-lines-by-pattern "TRI_ASSERT" \
         --print-summary \

--- a/scripts/coverage.fish
+++ b/scripts/coverage.fish
@@ -50,7 +50,6 @@ and gcovr --exclude-throw-branches --root /work/ArangoDB \
         -e /work/ArangoDB/3rdParty/jemalloc/v*/ \
         -e /work/ArangoDB/usr/ \
         -e /work/ArangoDB/tests \
-        -e /work/ArangoDB/arangod/Aql \
         -o coverage/coverage.xml \
         --exclude-lines-by-pattern "TRI_ASSERT" \
         --print-summary \
@@ -60,7 +59,8 @@ and cat coverage/coverage.xml \
       > coverage/coverage.xml.tmp
 and mv coverage/coverage.xml.tmp coverage/coverage.xml
 and for d in lib arangosh client-tools arangod enterprise/Enterprise
-  if test -d $d
+  if test -d /work/ArangoDB/$d
+  	echo "cp -a /work/ArangoDB/$d coverage/$d"
   	cp -a /work/ArangoDB/$d coverage/$d
   end
 end

--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -37,7 +37,7 @@ function launchClusterTests
 end
 
 ################################################################################
-## both tests: runtime,command
+## single and cluster tests: runtime,command
 ################################################################################
 
 function launchSingleClusterTests

--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -4,7 +4,7 @@ source $SCRIPTS/lib/tests.fish
 
 set -xg ADDITIONAL_OPTIONS $argv
 
-set ENTERPRISE_ARG ""
+set ENTERPRISE_ARG "--no-enterprise"
 if test "$ENTERPRISEEDITION" = "On"
    set ENTERPRISE_ARG "--enterprise"
 end

--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -4,13 +4,18 @@ source $SCRIPTS/lib/tests.fish
 
 set -xg ADDITIONAL_OPTIONS $argv
 
+set ENTERPRISE_ARG ""
+if test "$ENTERPRISEEDITION" = "On"
+   set ENTERPRISE_ARG "--enterprise"
+end
+
 ################################################################################
 ## Single tests: runtime,command
 ################################################################################
 
 function launchSingleTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --full
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --full $ENTERPRISE_ARG
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -20,7 +25,7 @@ end
 ################################################################################
 
 function launchGTest
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --gtest
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --gtest $ENTERPRISE_ARG
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -31,7 +36,7 @@ end
 
 function launchClusterTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --cluster --full
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --cluster --full $ENTERPRISE_ARG
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -42,7 +47,7 @@ end
 
 function launchSingleClusterTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --single_cluster --full
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --single_cluster --full $ENTERPRISE_ARG
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end

--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -15,7 +15,7 @@ end
 
 function launchSingleTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --full $ENTERPRISE_ARG
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --full "$ENTERPRISE_ARG"
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -25,7 +25,7 @@ end
 ################################################################################
 
 function launchGTest
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --gtest $ENTERPRISE_ARG
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --gtest "$ENTERPRISE_ARG"
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -36,7 +36,7 @@ end
 
 function launchClusterTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --cluster --full $ENTERPRISE_ARG
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --cluster --full "$ENTERPRISE_ARG"
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -47,7 +47,7 @@ end
 
 function launchSingleClusterTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --single_cluster --full $ENTERPRISE_ARG
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --single_cluster --full "$ENTERPRISE_ARG"
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end

--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -40,9 +40,9 @@ end
 ## both tests: runtime,command
 ################################################################################
 
-function launchBothTests
+function launchSingleClusterTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --both --full
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --single_cluster --full
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -74,10 +74,10 @@ switch $TESTSUITE
     resetLaunch 4
     set -xg timeLimit 16200
     set suiteRunner "launchClusterTests"
-  case "both"
+  case "single_cluster"
     resetLaunch 4
     set -xg timeLimit 25200
-    set suiteRunner "launchBothTests"
+    set suiteRunner "launchSingleClusterTests"
   case "single"
     resetLaunch 1
     set -xg timeLimit 9000

--- a/scripts/runFullTests.fish
+++ b/scripts/runFullTests.fish
@@ -37,6 +37,17 @@ function launchClusterTests
 end
 
 ################################################################################
+## both tests: runtime,command
+################################################################################
+
+function launchBothTests
+  echo "Using test definitions from arangodb repo"
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --both --full
+  and set -xg result "GOOD"
+  or set -xg result "BAD"
+end
+
+################################################################################
 ## main
 ################################################################################
 
@@ -63,6 +74,10 @@ switch $TESTSUITE
     resetLaunch 4
     set -xg timeLimit 16200
     set suiteRunner "launchClusterTests"
+  case "both"
+    resetLaunch 4
+    set -xg timeLimit 25200
+    set suiteRunner "launchBothTests"
   case "single"
     resetLaunch 1
     set -xg timeLimit 9000

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -35,12 +35,12 @@ function launchClusterTests
 end
 
 ################################################################################
-## both tests: runtime,command
+## single and cluster tests: runtime,command
 ################################################################################
 
-function launchBothTests
+function launchSingleClusterTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --both
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --single_cluster
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -72,10 +72,10 @@ switch $TESTSUITE
     resetLaunch 4
     set -xg timeLimit 4200
     set suiteRunner "launchClusterTests"
-  case "cluster"
+  case "single_cluster"
     resetLaunch 4
     set -xg timeLimit 8100
-    set suiteRunner "launchBothTests"
+    set suiteRunner "launchSingleClusterTests"
   case "single"
     resetLaunch 1
     set -xg  timeLimit 3900

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -13,7 +13,7 @@ end
 
 function launchSingleTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch $ENTERPRISE_ARG
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch "$ENTERPRISE_ARG"
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -23,7 +23,7 @@ end
 ################################################################################
 
 function launchGTest
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --gtest $ENTERPRISE_ARG
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --gtest "$ENTERPRISE_ARG"
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -34,7 +34,7 @@ end
 
 function launchClusterTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --cluster $ENTERPRISE_ARG
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --cluster "$ENTERPRISE_ARG"
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -45,7 +45,7 @@ end
 
 function launchSingleClusterTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --single_cluster $ENTERPRISE_ARG
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --single_cluster "$ENTERPRISE_ARG"
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -35,6 +35,17 @@ function launchClusterTests
 end
 
 ################################################################################
+## both tests: runtime,command
+################################################################################
+
+function launchBothTests
+  echo "Using test definitions from arangodb repo"
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --both
+  and set -xg result "GOOD"
+  or set -xg result "BAD"
+end
+
+################################################################################
 ## main
 ################################################################################
 
@@ -61,6 +72,10 @@ switch $TESTSUITE
     resetLaunch 4
     set -xg timeLimit 4200
     set suiteRunner "launchClusterTests"
+  case "cluster"
+    resetLaunch 4
+    set -xg timeLimit 8100
+    set suiteRunner "launchBothTests"
   case "single"
     resetLaunch 1
     set -xg  timeLimit 3900

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -2,7 +2,7 @@
 set -g SCRIPTS (dirname (status -f))
 source $SCRIPTS/lib/tests.fish
 
-set ENTERPRISE_ARG ""
+set ENTERPRISE_ARG "--no-enterprise"
 if test "$ENTERPRISEEDITION" = "On"
    set ENTERPRISE_ARG "--enterprise"
 end

--- a/scripts/runTests.fish
+++ b/scripts/runTests.fish
@@ -2,13 +2,18 @@
 set -g SCRIPTS (dirname (status -f))
 source $SCRIPTS/lib/tests.fish
 
+set ENTERPRISE_ARG ""
+if test "$ENTERPRISEEDITION" = "On"
+   set ENTERPRISE_ARG "--enterprise"
+end
+
 ################################################################################
 ## Single tests: runtime,command
 ################################################################################
 
 function launchSingleTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch $ENTERPRISE_ARG
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -18,7 +23,7 @@ end
 ################################################################################
 
 function launchGTest
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --gtest
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --gtest $ENTERPRISE_ARG
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -29,7 +34,7 @@ end
 
 function launchClusterTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --cluster
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --cluster $ENTERPRISE_ARG
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end
@@ -40,7 +45,7 @@ end
 
 function launchSingleClusterTests
   echo "Using test definitions from arangodb repo"
-  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --single_cluster
+  python3 "$WORKSPACE/jenkins/helper/test_launch_controller.py" "$INNERWORKDIR/ArangoDB/tests/test-definitions.txt" -f launch --single_cluster $ENTERPRISE_ARG
   and set -xg result "GOOD"
   or set -xg result "BAD"
 end

--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -19,7 +19,7 @@ Function global:registerSingleTests()
 
     Write-Host "Using test definitions from repo..."
     pip install py7zr
-    proc -process "python.exe" -argument "$env:WORKSPACE\jenkins\helper\test_launch_controller.py $INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -logfile $false -priority "Normal" $$ENTERPRISE_ARG
+    proc -process "python.exe" -argument "$env:WORKSPACE\jenkins\helper\test_launch_controller.py $INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -logfile $false -priority "Normal" $ENTERPRISE_ARG
 }
 
 Function global:registerClusterTests()
@@ -36,7 +36,7 @@ Function global:registerClusterTests()
 
     Write-Host "Using test definitions from repo..."
     pip install py7zr
-    proc -process "python.exe" -argument "$env:WORKSPACE\jenkins\helper\test_launch_controller.py $INNERWORKDIR\ArangoDB\tests\test-definitions.txt --cluster" -logfile $false -priority "Normal"  $$ENTERPRISE_ARG
+    proc -process "python.exe" -argument "$env:WORKSPACE\jenkins\helper\test_launch_controller.py $INNERWORKDIR\ArangoDB\tests\test-definitions.txt --cluster" -logfile $false -priority "Normal"  $ENTERPRISE_ARG
 }
 
 runTests

--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -11,7 +11,7 @@ Function global:registerSingleTests()
     Write-Host "Registering tests..."
 
     $env:TIMELIMIT = 3900
-    Set-Variable -Name ENTERPRISE_ARG ""
+    Set-Variable -Name ENTERPRISE_ARG "--no-enterprise"
     If ($ENTERPRISEEDITION -eq "On")
     {
         Set-Variable -Name ENTERPRISE_ARG "--enterprise"
@@ -19,7 +19,7 @@ Function global:registerSingleTests()
 
     Write-Host "Using test definitions from repo..."
     pip install py7zr
-    proc -process "python.exe" -argument "$env:WORKSPACE\jenkins\helper\test_launch_controller.py $INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -logfile $false -priority "Normal" $ENTERPRISE_ARG
+    proc -process "python.exe" -argument "$env:WORKSPACE\jenkins\helper\test_launch_controller.py $INNERWORKDIR\ArangoDB\tests\test-definitions.txt $ENTERPRISE_ARG" -logfile $false -priority "Normal" 
 }
 
 Function global:registerClusterTests()
@@ -28,7 +28,7 @@ Function global:registerClusterTests()
     Write-Host "Registering tests..."
 
     $env:TIMELIMIT = 6600
-    Set-Variable -Name ENTERPRISE_ARG ""
+    Set-Variable -Name ENTERPRISE_ARG "--no-enterprise"
     If ($ENTERPRISEEDITION -eq "On")
     {
         Set-Variable -Name ENTERPRISE_ARG "--enterprise"
@@ -36,7 +36,7 @@ Function global:registerClusterTests()
 
     Write-Host "Using test definitions from repo..."
     pip install py7zr
-    proc -process "python.exe" -argument "$env:WORKSPACE\jenkins\helper\test_launch_controller.py $INNERWORKDIR\ArangoDB\tests\test-definitions.txt --cluster" -logfile $false -priority "Normal"  $ENTERPRISE_ARG
+    proc -process "python.exe" -argument "$env:WORKSPACE\jenkins\helper\test_launch_controller.py $INNERWORKDIR\ArangoDB\tests\test-definitions.txt --cluster $ENTERPRISE_ARG" -logfile $false -priority "Normal"
 }
 
 runTests

--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -11,10 +11,15 @@ Function global:registerSingleTests()
     Write-Host "Registering tests..."
 
     $env:TIMELIMIT = 3900
+    Set-Variable -Name ENTERPRISE_ARG ""
+    If ($ENTERPRISEEDITION -eq "On")
+    {
+        Set-Variable -Name ENTERPRISE_ARG "--enterprise"
+    }
 
     Write-Host "Using test definitions from repo..."
     pip install py7zr
-    proc -process "python.exe" -argument "$env:WORKSPACE\jenkins\helper\test_launch_controller.py $INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -logfile $false -priority "Normal"
+    proc -process "python.exe" -argument "$env:WORKSPACE\jenkins\helper\test_launch_controller.py $INNERWORKDIR\ArangoDB\tests\test-definitions.txt" -logfile $false -priority "Normal" $$ENTERPRISE_ARG
 }
 
 Function global:registerClusterTests()
@@ -23,10 +28,15 @@ Function global:registerClusterTests()
     Write-Host "Registering tests..."
 
     $env:TIMELIMIT = 6600
+    Set-Variable -Name ENTERPRISE_ARG ""
+    If ($ENTERPRISEEDITION -eq "On")
+    {
+        Set-Variable -Name ENTERPRISE_ARG "--enterprise"
+    }
 
     Write-Host "Using test definitions from repo..."
     pip install py7zr
-    proc -process "python.exe" -argument "$env:WORKSPACE\jenkins\helper\test_launch_controller.py $INNERWORKDIR\ArangoDB\tests\test-definitions.txt --cluster" -logfile $false -priority "Normal"
+    proc -process "python.exe" -argument "$env:WORKSPACE\jenkins\helper\test_launch_controller.py $INNERWORKDIR\ArangoDB\tests\test-definitions.txt --cluster" -logfile $false -priority "Normal"  $$ENTERPRISE_ARG
 }
 
 runTests


### PR DESCRIPTION
- it will use on python run to run cluster and single server
- coredump compressing is now utilizing all cpus available
- it wil turn state to orange (jenkins jobs need to be configured to react to exit 5 hovever)
- I tried to get the gcov error messages lower, however, it seems that the current implementation doesn't properly work at all, but due to later issues.
- locating of source files for generating jenkins UI reports have been fixed
- enterprise tests filtering has been fixed