### PR TITLE
it seems that even the main iteration loop may throw. We don't care.

### DIFF
--- a/jenkins/helper/socket_counter.py
+++ b/jenkins/helper/socket_counter.py
@@ -42,6 +42,10 @@ def get_socket_count():
                         pass
         except ProcessLookupError:
             pass
+        except psutil.ZombieProcess:
+            pass
+        except psutil.NoSuchProcess:
+            pass
     else:
         for socket in psutil.net_connections(kind='inet'):
             if socket.status in INTERESTING_SOCKETS:


### PR DESCRIPTION
https://github.com/arangodb/oskar/pull/463/files was intended to fix this incident, however it can not only happen in 
```
psutil.Process(proc.pid).connections():
```
but in 
```
psutil.process_iter(['pid', 'name']):
```
as well. We Don'c tare.