### PR TITLE
Changed config path

### DIFF
--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -222,7 +222,7 @@ class SiteConfig:
  - {self.core_dozend} / {self.loop_sleep} machine size / loop frequency
  - {socket_count} number of currently active tcp sockets
 {san_cov_msg}""")
-        self.cfgdir = base_source_dir / 'etc' / 'relative'
+        self.cfgdir = base_source_dir / 'etc' / 'testing'
         self.bin_dir = bin_dir
         self.base_path = base_source_dir
         self.test_data_dir = base_source_dir


### PR DESCRIPTION
Changed path were test scripts locate configuration files from `etc/relative` to `etc/testing`. These paths contain `arangosh.conf`, which we were reading from `etc/relative` in test environment.
There's a PR in devel relative to this change https://github.com/arangodb/arangodb/pull/18348.