### PR TITLE
prepend overload strings to lines

### DIFF
--- a/jenkins/helper/async_client.py
+++ b/jenkins/helper/async_client.py
@@ -432,7 +432,7 @@ class ArangoCLIprogressiveTimeoutExecutor:
                     if overload and not params['overload']:
                         add_message_to_report(
                             params,
-                            overload,
+                            overload + self.cfg.get_max(),
                             False)
                     params['overload'] = overload
                     line = queue.get(timeout=1)

--- a/jenkins/helper/async_client.py
+++ b/jenkins/helper/async_client.py
@@ -115,7 +115,7 @@ def logfile_line_result(wait, line, params):
         if params['trace']:
             print("e: " + str(line[0], 'utf-8').rstrip())
         if params["overload"]:
-            params['output'].write(params["overload"] + line[0])
+            params['output'].write(bytes(params["overload"], 'utf-8') + line[0])
         else:
             params['output'].write(line[0])
     return True

--- a/jenkins/helper/async_client.py
+++ b/jenkins/helper/async_client.py
@@ -45,6 +45,7 @@ def default_line_result(wait, line, params):
 def make_default_params(verbose, identifier):
     """ create the structure to work with arrays to output the strings to """
     return {
+        "overload": None,
         "trace_io": False,
         "error": "",
         "verbose": verbose,
@@ -72,6 +73,7 @@ def tail_line_result(wait, line, params):
 def make_tail_params(verbose, prefix, logfile):
     """ create the structure to work with arrays to output the strings to """
     return {
+        "overload": None,
         "trace_io": False,
         "error": "",
         "verbose": verbose,
@@ -92,6 +94,7 @@ def delete_tail_params(params):
 def make_logfile_params(verbose, logfile, trace, temp_dir):
     """ create the structure to work with logfiles """
     return {
+        "overload": None,
         "trace_io": True,
         "trace": trace,
         "error": "",
@@ -111,7 +114,10 @@ def logfile_line_result(wait, line, params):
     if isinstance(line, tuple):
         if params['trace']:
             print("e: " + str(line[0], 'utf-8').rstrip())
-        params['output'].write(line[0])
+        if params["overload"]:
+            params['output'].write(params["overload"] + line[0])
+        else:
+            params['output'].write(line[0])
     return True
 def delete_logfile_params(params):
     """ teardown the structure to work with logfiles """
@@ -422,12 +428,7 @@ class ArangoCLIprogressiveTimeoutExecutor:
                 result_line_handler(tcount, None, params)
                 line = ""
                 try:
-                    overload = self.cfg.get_overload()
-                    if overload:
-                        add_message_to_report(
-                            params,
-                            overload,
-                            False)
+                    params.overload = self.cfg.get_overload()
                     line = queue.get(timeout=1)
                     ret = result_line_handler(0, line, params)
                     line_filter = line_filter or ret

--- a/jenkins/helper/async_client.py
+++ b/jenkins/helper/async_client.py
@@ -428,7 +428,13 @@ class ArangoCLIprogressiveTimeoutExecutor:
                 result_line_handler(tcount, None, params)
                 line = ""
                 try:
-                    params.overload = self.cfg.get_overload()
+                    overload = self.cfg.get_overload()
+                    if overload and not params['overload']:
+                        add_message_to_report(
+                            params,
+                            overload,
+                            False)
+                    params['overload'] = overload
                     line = queue.get(timeout=1)
                     ret = result_line_handler(0, line, params)
                     line_filter = line_filter or ret

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -224,5 +224,5 @@ class SiteConfig:
         """ estimate whether the system is overloaded """
         load = psutil.getloadavg()
         if load[0] > self.overload:
-            return f"HIGH SYSTEM LOAD! {load[0]:9.2f} > {self.overload:9.2f} "
+            return f"HL[{load[0]:9.2f} > {self.overload:9.2f}]"
         return None

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -228,5 +228,5 @@ class SiteConfig:
         """ estimate whether the system is overloaded """
         load = psutil.getloadavg()
         if load[0] > self.overload:
-            return f"HL[{load[0]:3.2f} ] "
+            return f"HIGH LOAD[{load[0]:3.2f} ] "
         return None

--- a/jenkins/helper/site_config.py
+++ b/jenkins/helper/site_config.py
@@ -220,9 +220,13 @@ class SiteConfig:
         """ check whether we run an instrumented build """
         return self.is_asan or self.is_aulsan or self.is_gcov
 
+    def get_max(self):
+        """ get the maximal value before overlead is triggered """
+        return f'> {self.overload:9.2f}'
+
     def get_overload(self):
         """ estimate whether the system is overloaded """
         load = psutil.getloadavg()
         if load[0] > self.overload:
-            return f"HL[{load[0]:9.2f} > {self.overload:9.2f}]"
+            return f"HL[{load[0]:3.2f} ] "
         return None


### PR DESCRIPTION
Will change the testoutput in the following way:
- 3 well distinguishable lines marking the start of high system load
- subsequent lines will be prepended with a compact message to mark the tests that may suffer from starvation
```
2023-04-12T01:50:15.557Z [     PASSED ] testViewModifyImmutableProperties (setUp: 0ms, test: 2818ms, tearDown: 0ms)
OSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAR
OSKAR  2023-04-12 03:50:15.557482 - HIGH LOAD [7.70 ] >      7.56                  OSKAR
OSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAR
HIGH LOAD[7.70 ] 2023-04-12T01:50:17.292Z [------------] 1 tests from IResearchFeatureDDLTestSuite ran (tearDownAll: 1735ms)
HIGH LOAD[7.70 ] 2023-04-12T01:50:17.292Z [   PASSED   ] 1 tests.
HIGH LOAD[7.70 ] 2023-04-12T01:50:17.292Z [============] Ran: 1 tests (1 passed, 0 failed) (4699ms total)
```