### PR TITLE
modify filter to match gtest*

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ if supported, set number of concurrent builds to `PARALLELISM`
     - `single`: this test requires a single server
     - `full`: this test is only executed in full tests
     - `!full`: this test is only executed in non-full tests
-    - `gtest`: only the gtests are to be executed
+    - `gtest`: only testsuites starting with 'gtest' are to be executed
     - `ldap`: ldap
     - `enterprise`: this test is only executed with the enterprise version
     - `!windows`: test is excluded from Windows runs
@@ -277,7 +277,7 @@ if supported, set number of concurrent builds to `PARALLELISM`
     - `!arm`: test is excluded from ARM Linux / MacOS hosts 
  - `--cluster` filter `test-definition.txt` for all tests flagged as `cluster`
  - `--full` - all tests including those flagged as `full` are executed.
- - `--gtest` - only gtests are executed
+ - `--gtest` - only testsuites starting with 'gtest' are executed
  - `--all` - output unfiltered
  
 ### Syntax in `test-definition.txt`

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -91,7 +91,7 @@ known_flags = {
     "single": "this test requires a single server",
     "full": "this test is only executed in full tests",
     "!full": "this test is only executed in non-full tests",
-    "gtest": "only the gtest are to be executed",
+    "gtest": "only the testsuites starting with 'gtest' are to be executed",
     "sniff": "whether tcpdump / ngrep should be used",
     "ldap": "ldap",
     "enterprise": "this tests is only executed with the enterprise version",
@@ -141,7 +141,7 @@ def parse_arguments():
     parser.add_argument("--enterprise", help="add enterprise tests", action="store_true")
     parser.add_argument("--no-enterprise", help="add enterprise tests", action="store_true")
     parser.add_argument("--full", help="output full test set", action="store_true")
-    parser.add_argument("--gtest", help="only run gtest", action="store_true")
+    parser.add_argument("--gtest", help="only run gtest-suites", action="store_true")
     parser.add_argument("--all", help="output all test, ignore other filters", action="store_true")
     parser.add_argument("--no-report", help="don't create testreport and crash tarballs", type=bool)
     args = parser.parse_args()

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -38,7 +38,7 @@ def filter_tests(args, tests):
             filters.append(lambda test: "full" not in test["flags"])
 
         if args.gtest:
-            filters.append(lambda test: "gtest" ==  test["name"])
+            filters.append(lambda test: test["name"].startswith("gtest"))
 
         if not args.enterprise:
             filters.append(lambda test: "enterprise" not in test["flags"])


### PR DESCRIPTION
we need to run any gtest-suites with this filter, not only exact matches.

Hence we use 
```
>>> a='gtest_bla'
>>> a.startswith('gtest')
True
````
as filter 