### PR TITLE
QA-4048: launching RTA from oskar

### DIFF
--- a/helper.fish
+++ b/helper.fish
@@ -1960,7 +1960,7 @@ function moveResultsToWorkspace
 
     set -l matches $WORKDIR/work/*.{asc,testfailures.txt,deb,dmg,rpm,7z,tar.gz,tar.bz2,zip,html,csv,tar}
     for f in $matches
-      echo $f | grep -qv testreport ; and echo "mv $f" ; and mv $f $WORKSPACE; or echo "skipping $f"
+      echo $f | grep -qv testreport ; and echo "mv $f $WORKSPACE" ; and mv $f $WORKSPACE; or echo "skipping $f"
     end
 
     for f in $WORKDIR/work/*san.log.* ; echo "mv $f" ; mv $f $WORKSPACE/(basename $f).log ; end

--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -316,6 +316,11 @@ function checkoutMiniChaos
   or return $status
 end
 
+function checkoutRTA
+  runInContainer $ALPINEUTILSIMAGE $SCRIPTSDIR/checkoutRTA.fish
+  or return $status
+end
+
 function switchBranches
   set -l force_clean false
 

--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -317,7 +317,7 @@ function checkoutMiniChaos
 end
 
 function checkoutRTA
-  runInContainer $ALPINEUTILSIMAGE -e RTA_BRANCH="$RTA_BRANCH" $SCRIPTSDIR/checkoutRTA.fish
+  runInContainer -e RTA_BRANCH="$RTA_BRANCH" $ALPINEUTILSIMAGE $SCRIPTSDIR/checkoutRTA.fish
   or return $status
 end
 

--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -2121,6 +2121,17 @@ function downloadSyncer
   and convertSItoJSON
 end
 
+function downloadAuxBinariesToBuildBin
+  if test "$ENTERPRISEEDITION" = "On"
+     copyRclone linux
+     and cp work/ArangoDB/build/install/usr/sbin/rclone-arangodb work/ArangoDB/build/bin/
+     and downloadSyncer
+     and cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
+  end
+  and downloadStarter
+  and cp work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
+end
+
 ## #############################################################################
 ## set PARALLELISM in a sensible way
 ## #############################################################################

--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -317,7 +317,7 @@ function checkoutMiniChaos
 end
 
 function checkoutRTA
-  runInContainer $ALPINEUTILSIMAGE $SCRIPTSDIR/checkoutRTA.fish
+  runInContainer $ALPINEUTILSIMAGE -e RTA_BRANCH="$RTA_BRANCH" $SCRIPTSDIR/checkoutRTA.fish
   or return $status
 end
 

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -3,6 +3,10 @@ source jenkins/helper/jenkins.fish
 
 cleanPrepareLockUpdateClear2
 TT_init
+set RTA_EDITION "C"
+if test "$ENTERPRISEEDITION" = "On"
+   set RTA_EDITION "EP"
+end
 
 and eval $EDITION
 and eval $TEST_SUITE
@@ -13,23 +17,10 @@ and pingDetails
 and TT_setup
 and oskarCompile
 and TT_compile
-and downloadStarter
-cp work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
-cp /work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
-#       work/ArangoDB/build/install/usr/bin/arangodb
-set RTA_EDITION "C"
-if test "$ENTERPRISEEDITION" = "On"
-   set RTA_EDITION "EP"
-   copyRclone linux
-   cp work/ArangoDB/build/install/usr/sbin/rclone-arangodb work/ArangoDB/build/bin/
-   downloadSyncer
-   cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
-   pwd
-   find work
-end
+and downloadAuxBinariesToBuildBin
 
-checkoutRTA
-cd work/release-test-automation/
-git checkout $RTA_BRANCH
-bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION $ADDITIONAL_PARAMS
+and checkoutRTA
+and cd work/release-test-automation/
+# git checkout $RTA_BRANCH
+and bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION $ADDITIONAL_PARAMS
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -28,5 +28,6 @@ end
 
 checkoutRTA
 cd work/release-test-automation/
+git checkout $RTA_BRANCH
 bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -36,7 +36,7 @@ if test "$ENTERPRISEEDITION" = "On"
    copyRclone linux
 end
 pwd
-find work/
+# find work/
 
 checkoutRTA
 

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -13,17 +13,24 @@ and setAllLogsToWorkspace
 and switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
 and updateDockerBuildImage
 and pingDetails
+echo "santoeuhsanoteuhxxxx"
 and TT_setup
-and oskarCompile
+# and oskarCompile
 and TT_compile
+echo "santoeuhsanoteuh"
 
-and downloadStarter
-and downloadSyncer
-and copyRclone
-and checkoutRTA
+downloadStarter
+pwd
+cp work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
+# and downloadSyncer
+# cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
+# and copyRclone
+checkoutRTA
 
 pwd
 cd work/release-test-automation/
+git checkout feature/mixed-source-zip-upgrade
+chmod a+x ./jenkins/oskar_tar.sh
 ./jenkins/oskar_tar.sh
 # cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -2,7 +2,7 @@
 source jenkins/helper/jenkins.fish
 
 cleanPrepareLockUpdateClear2
-and TT_init
+TT_init
 
 and eval $EDITION
 and eval $STORAGE_ENGINE
@@ -30,7 +30,7 @@ checkoutRTA
 pwd
 cd work/release-test-automation/
 git checkout feature/mixed-source-zip-upgrade
-chmod a+x ./jenkins/oskar_tar.sh
+chmod a+x ./jenkins/oskar_tar.sh --starter-mode SG
 ./jenkins/oskar_tar.sh
 # cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -18,7 +18,6 @@ and downloadAuxBinariesToBuildBin
 
 and checkoutRTA
 and cd work/release-test-automation/
-# git checkout $RTA_BRANCH
 if test "$ENTERPRISEEDITION" = "On"
    set RTA_EDITION "EP"
 end

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -21,7 +21,7 @@ and cd work/release-test-automation/
 if test "$ENTERPRISEEDITION" = "On"
    set RTA_EDITION "EP"
 end
-and bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION $ADDITIONAL_PARAMS
+and bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION $argv
 
 set -l s $status
 

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -29,15 +29,14 @@ pwd
 cp work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
 downloadSyncer
 cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
-copyRclone
-find work/Arangodb/build/install/usr/bin
-find work/Arangodb/build/install/usr/sbin
+copyRclone linux
+find work/Arangodb/build/
 checkoutRTA
 
 pwd
 cd work/release-test-automation/
 git checkout feature/mixed-source-zip-upgrade
 chmod a+x ./jenkins/oskar_tar.sh
-./jenkins/oskar_tar.sh
+./jenkins/oskar_tar.sh --edition C
 # cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -20,12 +20,9 @@ and TT_compile
 and downloadStarter
 and downloadSyncer
 and copyRclone
+and checkoutRTA
 
-and oskar
-
-set -l s $status
-
-TT_tests
-
-cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory 
+cd $INNERWORKDIR/release-test-automation/
+./jenkins/oskar_tar.sh
+# cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -22,7 +22,17 @@ if test "$ENTERPRISEEDITION" = "On"
    set RTA_EDITION "EP"
 end
 and bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION $ADDITIONAL_PARAMS
+
 set -l s $status
+
+# compiling results:
+moveResultsToWorkspace
 # RTA leaves its results here:
-cd test_dir; moveResultsToWorkspace ; unlockDirectory
+cd test_dir
+set ws "$WORKSPACE"
+set set -gx WORKSPACE (pwd)
+moveResultsToWorkspace
+set WORKSPACE "$ws"
+unlockDirectory
+
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -1,0 +1,31 @@
+#!/usr/bin/env fish
+source jenkins/helper/jenkins.fish
+
+cleanPrepareLockUpdateClear2
+and TT_init
+
+and eval $EDITION
+and eval $STORAGE_ENGINE
+and eval $TEST_SUITE
+and skipGrey
+and setAllLogsToWorkspace
+
+and switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
+and updateDockerBuildImage
+and pingDetails
+and TT_setup
+and oskarCompile
+and TT_compile
+
+and downloadStarter
+and downloadSyncer
+and copyRclone
+
+and oskar
+
+set -l s $status
+
+TT_tests
+
+cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory 
+exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -30,7 +30,7 @@ moveResultsToWorkspace
 
 set -l matches $WORKDIR/work/release-test-automation/test_dir/*.{asc,testfailures.txt,deb,dmg,rpm,7z,tar.gz,tar.bz2,zip,html,csv,tar,png}
 for f in $matches
-   echo $f | grep -qv testreport ; and echo "mv $f" ; and mv $f $WORKSPACE; or echo "skipping $f"
+   echo $f | grep -qv testreport ; and echo "mv $f $WORKSPACE" ; and mv $f $WORKSPACE; or echo "skipping $f"
 end
 
 unlockDirectory

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -25,14 +25,9 @@ and bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION $argv
 
 set -l s $status
 
-# compiling results:
-moveResultsToWorkspace
 # RTA leaves its results here:
-cd test_dir
-set ws "$WORKSPACE"
-set set -gx WORKSPACE (pwd)
+cd test_dir; mv *.7z *.png ../..; cd ..
 moveResultsToWorkspace
-set WORKSPACE "$ws"
 unlockDirectory
 
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -31,5 +31,5 @@ end
 checkoutRTA
 cd work/release-test-automation/
 git checkout $RTA_BRANCH
-bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION
+bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION $ADDITIONAL_PARAMS
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -4,46 +4,29 @@ source jenkins/helper/jenkins.fish
 cleanPrepareLockUpdateClear2
 TT_init
 
-eval $EDITION
-eval $TEST_SUITE
-skipGrey
-setAllLogsToWorkspace
-echo "1 $status"
-switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
-echo "2 $status"
-updateDockerBuildImage
-echo "3 $status"
-pingDetails
-echo "4 $status"
-echo "santoeuhsanoteuhxxxx"
-TT_setup
-echo "5 $status"
-oskarCompile
-echo "6 $status"
-TT_compile
-echo "santoeuhsanoteuh"
-
-downloadStarter
+and eval $EDITION
+and eval $TEST_SUITE
+and setAllLogsToWorkspace
+and switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
+and updateDockerBuildImage
+and pingDetails
+and TT_setup
+and oskarCompile
+and TT_compile
+and downloadStarter
 cp work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
 cp /work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
 #       work/ArangoDB/build/install/usr/bin/arangodb
-set RTA_EDITION C
+set RTA_EDITION "C"
 if test "$ENTERPRISEEDITION" = "On"
-   set RTA_EDITION EP
-
+   set RTA_EDITION "EP"
+   copyRclone linux
+   cp work/ArangoDB/build/install/usr/bin/rclone-arangodb work/ArangoDB/build/bin/
    downloadSyncer
    cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
-   copyRclone linux
 end
-pwd
-# find work/
 
 checkoutRTA
-
-pwd
 cd work/release-test-automation/
-git checkout feature/mixed-source-zip-upgrade
-chmod a+x ./jenkins/oskar_tar.sh
 bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION
-# cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -24,6 +24,8 @@ if test "$ENTERPRISEEDITION" = "On"
    cp work/ArangoDB/build/install/usr/bin/rclone-arangodb work/ArangoDB/build/bin/
    downloadSyncer
    cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
+   pwd
+   find work
 end
 
 checkoutRTA

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -22,4 +22,7 @@ if test "$ENTERPRISEEDITION" = "On"
    set RTA_EDITION "EP"
 end
 and bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION $ADDITIONAL_PARAMS
+set -l s $status
+# RTA leaves its results here:
+cd test_dir; moveResultsToWorkspace ; unlockDirectory
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -4,9 +4,6 @@ source jenkins/helper/jenkins.fish
 cleanPrepareLockUpdateClear2
 TT_init
 set RTA_EDITION "C"
-if test "$ENTERPRISEEDITION" = "On"
-   set RTA_EDITION "EP"
-end
 
 and eval $EDITION
 and eval $TEST_SUITE
@@ -22,5 +19,8 @@ and downloadAuxBinariesToBuildBin
 and checkoutRTA
 and cd work/release-test-automation/
 # git checkout $RTA_BRANCH
+if test "$ENTERPRISEEDITION" = "On"
+   set RTA_EDITION "EP"
+end
 and bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION $ADDITIONAL_PARAMS
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -24,10 +24,13 @@ TT_compile
 echo "santoeuhsanoteuh"
 
 downloadStarter
+cp work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
+cp /work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
+#       work/ArangoDB/build/install/usr/bin/arangodb
 set RTA_EDITION C
 if test "$ENTERPRISEEDITION" = "On"
    set RTA_EDITION EP
-   cp work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
+
    downloadSyncer
    cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
    copyRclone linux

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -4,27 +4,32 @@ source jenkins/helper/jenkins.fish
 cleanPrepareLockUpdateClear2
 TT_init
 
-and eval $EDITION
-and eval $STORAGE_ENGINE
-and eval $TEST_SUITE
-and skipGrey
-and setAllLogsToWorkspace
-
-and switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
-and updateDockerBuildImage
-and pingDetails
+eval $EDITION
+eval $STORAGE_ENGINE
+eval $TEST_SUITE
+skipGrey
+setAllLogsToWorkspace
+echo "1 $status"
+switchBranches $ARANGODB_BRANCH $ENTERPRISE_BRANCH true
+echo "2 $status"
+updateDockerBuildImage
+echo "3 $status"
+pingDetails
+echo "4 $status"
 echo "santoeuhsanoteuhxxxx"
-and TT_setup
-# and oskarCompile
-and TT_compile
+TT_setup
+echo "5 $status"
+oskarCompile
+echo "6 $status"
+TT_compile
 echo "santoeuhsanoteuh"
 
 downloadStarter
 pwd
 cp work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
-# and downloadSyncer
+# downloadSyncer
 # cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
-# and copyRclone
+# copyRclone
 checkoutRTA
 
 pwd

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -5,7 +5,6 @@ cleanPrepareLockUpdateClear2
 TT_init
 
 eval $EDITION
-eval $STORAGE_ENGINE
 eval $TEST_SUITE
 skipGrey
 setAllLogsToWorkspace
@@ -25,18 +24,23 @@ TT_compile
 echo "santoeuhsanoteuh"
 
 downloadStarter
+set RTA_EDITION C
+if test "$ENTERPRISEEDITION" = "On"
+   set RTA_EDITION EP
+   cp work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
+   downloadSyncer
+   cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
+   copyRclone linux
+end
 pwd
-cp work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
-downloadSyncer
-cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
-copyRclone linux
-find work/Arangodb/build/
+find work/
+
 checkoutRTA
 
 pwd
 cd work/release-test-automation/
 git checkout feature/mixed-source-zip-upgrade
 chmod a+x ./jenkins/oskar_tar.sh
-./jenkins/oskar_tar.sh --edition C
+bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION
 # cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -22,7 +22,8 @@ and downloadSyncer
 and copyRclone
 and checkoutRTA
 
-cd $INNERWORKDIR/release-test-automation/
+pwd
+cd work/release-test-automation/
 ./jenkins/oskar_tar.sh
 # cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -21,7 +21,7 @@ set RTA_EDITION "C"
 if test "$ENTERPRISEEDITION" = "On"
    set RTA_EDITION "EP"
    copyRclone linux
-   cp work/ArangoDB/build/install/usr/bin/rclone-arangodb work/ArangoDB/build/bin/
+   cp work/ArangoDB/build/install/usr/sbin/rclone-arangodb work/ArangoDB/build/bin/
    downloadSyncer
    cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
    pwd

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -30,7 +30,7 @@ checkoutRTA
 pwd
 cd work/release-test-automation/
 git checkout feature/mixed-source-zip-upgrade
-chmod a+x ./jenkins/oskar_tar.sh --starter-mode SG
+chmod a+x ./jenkins/oskar_tar.sh
 ./jenkins/oskar_tar.sh
 # cd "$HOME/$NODE_NAME/$OSKAR" ; moveResultsToWorkspace ; unlockDirectory
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -25,9 +25,14 @@ and bash -x ./jenkins/oskar_tar.sh --edition $RTA_EDITION $argv
 
 set -l s $status
 
-# RTA leaves its results here:
-cd test_dir; mv *.7z *.png ../..; cd ..
+# compiling results:
 moveResultsToWorkspace
+# RTA leaves its results here:
+cd test_dir
+set wd "$WORKDIR"
+set set -gx WORKDIR (pwd)
+moveResultsToWorkspace
+set WORKDIR "$wd"
 unlockDirectory
 
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -27,12 +27,12 @@ set -l s $status
 
 # compiling results:
 moveResultsToWorkspace
-# RTA leaves its results here:
-cd test_dir
-set wd "$WORKDIR"
-set set -gx WORKDIR (pwd)
-moveResultsToWorkspace
-set WORKDIR "$wd"
+
+set -l matches $WORKDIR/work/release-test-automation/test_dir/*.{asc,testfailures.txt,deb,dmg,rpm,7z,tar.gz,tar.bz2,zip,html,csv,tar,png}
+for f in $matches
+   echo $f | grep -qv testreport ; and echo "mv $f" ; and mv $f $WORKSPACE; or echo "skipping $f"
+end
+
 unlockDirectory
 
 exit $s

--- a/jenkins/runRTAtest.fish
+++ b/jenkins/runRTAtest.fish
@@ -27,9 +27,11 @@ echo "santoeuhsanoteuh"
 downloadStarter
 pwd
 cp work/ArangoDB/build/install/usr/bin/arangodb work/ArangoDB/build/bin/
-# downloadSyncer
-# cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
-# copyRclone
+downloadSyncer
+cp work/ArangoDB/build/install/usr/sbin/arangosync work/ArangoDB/build/bin/
+copyRclone
+find work/Arangodb/build/install/usr/bin
+find work/Arangodb/build/install/usr/sbin
 checkoutRTA
 
 pwd

--- a/scripts/checkoutRTA.fish
+++ b/scripts/checkoutRTA.fish
@@ -6,7 +6,9 @@ set -l mirror
 if test -d /mirror/release-test-automation.git
   set mirror --reference-if-able /mirror/release-test-automation.git
 end
-
+echo "in here"
+echo $RTA_BRANCH
+echo "go"
 cd $INNERWORKDIR
 and git config --global http.postBuffer 524288000
 and git config --global https.postBuffer 524288000

--- a/scripts/checkoutRTA.fish
+++ b/scripts/checkoutRTA.fish
@@ -6,9 +6,6 @@ set -l mirror
 if test -d /mirror/release-test-automation.git
   set mirror --reference-if-able /mirror/release-test-automation.git
 end
-echo "in here"
-echo $RTA_BRANCH
-echo "go"
 cd $INNERWORKDIR
 and git config --global http.postBuffer 524288000
 and git config --global https.postBuffer 524288000

--- a/scripts/checkoutRTA.fish
+++ b/scripts/checkoutRTA.fish
@@ -23,5 +23,7 @@ and if test ! -d release-test-automation
     and git repack -a
     and git submodule init
     and git submodule update
+    and git checkout $RTA_BRANCH
+    and git submodule update
   end
 end

--- a/scripts/checkoutRTA.fish
+++ b/scripts/checkoutRTA.fish
@@ -21,5 +21,7 @@ and if test ! -d release-test-automation
   and if test -d /mirror/release-test-automation.git
     cd release-test-automation
     and git repack -a
+    and git submodule init
+    and git submodule update
   end
 end

--- a/scripts/checkoutRTA.fish
+++ b/scripts/checkoutRTA.fish
@@ -1,0 +1,25 @@
+#!/usr/bin/env fish
+ssh -o StrictHostKeyChecking=no -T git@github.com
+
+set -l mirror
+
+if test -d /mirror/release-test-automation.git
+  set mirror --reference-if-able /mirror/release-test-automation.git
+end
+
+cd $INNERWORKDIR
+and git config --global http.postBuffer 524288000
+and git config --global https.postBuffer 524288000
+and git config --global pull.rebase true
+and if test ! -d release-test-automation/.git
+  rm -rf release-test-automation
+end
+and if test ! -d release-test-automation
+  echo == (date) == started clone 'RTA'
+  and git clone --progress $mirror ssh://git@github.com/arangodb/release-test-automation
+  and echo == (date) == finished clone 'ArangoDB'
+  and if test -d /mirror/release-test-automation.git
+    cd release-test-automation
+    and git repack -a
+  end
+end

--- a/scripts/checkoutRTA.fish
+++ b/scripts/checkoutRTA.fish
@@ -17,7 +17,7 @@ end
 and if test ! -d release-test-automation
   echo == (date) == started clone 'RTA'
   and git clone --progress $mirror ssh://git@github.com/arangodb/release-test-automation
-  and echo == (date) == finished clone 'ArangoDB'
+  and echo == (date) == finished clone 'release test automation'
   and if test -d /mirror/release-test-automation.git
     cd release-test-automation
     and git repack -a


### PR DESCRIPTION
This PR is related to this effort: https://github.com/arangodb/release-test-automation/pull/365

- [jenkins/runRTAtest.fish](https://github.com/arangodb/oskar/pull/523/files#diff-693f11ab86c5e45b3295282346b8fb6ef0fa89e888eef251ccbc6c6c757e35ef) is a copied & edited version of https://github.com/arangodb/oskar/blob/master/scripts/checkoutArangoDB.fish altered to do the very same for RTA as to do for the ArangoDB source.
- helper.fish patch wraps above new file
- https://github.com/arangodb/oskar/pull/523/files#diff-693f11ab86c5e45b3295282346b8fb6ef0fa89e888eef251ccbc6c6c757e35ef is the intended jenkins invokeable script. It is mostly similar to runPRtest2.fish, but adds downloading of 
  - the starter
  - the syncer
  - rclone
  - launch RTA against this.
- https://github.com/arangodb/release-test-automation/pull/365/files#diff-cfc685fd5d0867ed348db390084477cecae95997fb067bbe72f2f537502492ef is invoked in order to launch RTA by mounting 