### PR TITLE
leave a message why we turn red

### DIFF
--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -460,7 +460,7 @@ class TestingRunner():
         if len(core_files_list) == 0 or core_max_count <= 0:
             print(f'Coredumps are not collected: {str(len(core_files_list))} coredumps found; coredumps max limit to collect is {str(core_max_count)}!')
             return
-        if not self.crashed:
+        if not self.crashed or self.success:
             self.append_report_txt("non captured crash reports found; please inspect the tests to find out who created them.")
         self.crashed = True
         self.success = False

--- a/jenkins/helper/testing_runner.py
+++ b/jenkins/helper/testing_runner.py
@@ -460,6 +460,8 @@ class TestingRunner():
         if len(core_files_list) == 0 or core_max_count <= 0:
             print(f'Coredumps are not collected: {str(len(core_files_list))} coredumps found; coredumps max limit to collect is {str(core_max_count)}!')
             return
+        if not self.crashed:
+            self.append_report_txt("non captured crash reports found; please inspect the tests to find out who created them.")
         self.crashed = True
         self.success = False
         core_zip_dir = get_workspace() / 'coredumps'


### PR DESCRIPTION
If we find crashes without failing tests tell the user in testfailures.txt