### PR TITLE
remove compile option `-fno-stack-protector`

### DIFF
--- a/scripts/buildAlpine6.fish
+++ b/scripts/buildAlpine6.fish
@@ -40,10 +40,10 @@ set -g FULLARGS $argv \
 
 if test "$MAINTAINER" = "On"
   set -g FULLARGS $FULLARGS \
-    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie -fno-stack-protector"
+    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie"
 else
   set -g FULLARGS $FULLARGS \
-    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie $inline -fno-stack-protector" \
+    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie $inline" \
     -DUSE_CATCH_TESTS=Off \
     -DUSE_GOOGLE_TESTS=Off
 end
@@ -53,14 +53,14 @@ if test "$BUILD_SEPP" = "On"
 end
 
 if test "$SAN" = "On"
-  echo "SAN is not support in this environment"
+  echo "SAN is not supported in this environment"
   exit 1
 else if test "$COVERAGE" = "On"
   echo "Building with Coverage"
   set -g FULLARGS $FULLARGS \
     -DUSE_JEMALLOC=$JEMALLOC_OSKAR \
-    -DCMAKE_C_FLAGS="$pie -fno-stack-protector -fprofile-arcs -ftest-coverage" \
-    -DCMAKE_CXX_FLAGS="$pie -fno-stack-protector -fprofile-arcs -ftest-coverage" \
+    -DCMAKE_C_FLAGS="$pie -fprofile-arcs -ftest-coverage" \
+    -DCMAKE_CXX_FLAGS="$pie -fprofile-arcs -ftest-coverage" \
     -DUSE_COVERAGE=ON
 else
   set -g FULLARGS $FULLARGS \
@@ -68,12 +68,12 @@ else
 
   if test "$MAINTAINER" = "On"
     set -g FULLARGS $FULLARGS \
-     -DCMAKE_C_FLAGS="$pie -fno-stack-protector" \
-     -DCMAKE_CXX_FLAGS="$pie -fno-stack-protector"
+     -DCMAKE_C_FLAGS="$pie" \
+     -DCMAKE_CXX_FLAGS="$pie"
   else
     set -g FULLARGS $FULLARGS \
-     -DCMAKE_C_FLAGS="$pie $inline -fno-stack-protector" \
-     -DCMAKE_CXX_FLAGS="$pie $inline -fno-stack-protector"
+     -DCMAKE_C_FLAGS="$pie $inline" \
+     -DCMAKE_CXX_FLAGS="$pie $inline"
   end
 end
 

--- a/scripts/buildAlpine7.fish
+++ b/scripts/buildAlpine7.fish
@@ -40,10 +40,10 @@ set -g FULLARGS $argv \
 
 if test "$MAINTAINER" = "On"
   set -g FULLARGS $FULLARGS \
-    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie -fno-stack-protector"
+    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie"
 else
   set -g FULLARGS $FULLARGS \
-    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie $inline -fno-stack-protector" \
+    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie $inline" \
     -DUSE_CATCH_TESTS=Off \
     -DUSE_GOOGLE_TESTS=Off
 end
@@ -59,8 +59,8 @@ else if test "$COVERAGE" = "On"
   echo "Building with Coverage"
   set -g FULLARGS $FULLARGS \
     -DUSE_JEMALLOC=$JEMALLOC_OSKAR \
-    -DCMAKE_C_FLAGS="$pie -fno-stack-protector -fprofile-arcs -ftest-coverage" \
-    -DCMAKE_CXX_FLAGS="$pie -fno-stack-protector -fprofile-arcs -ftest-coverage" \
+    -DCMAKE_C_FLAGS="$pie -fprofile-arcs -ftest-coverage" \
+    -DCMAKE_CXX_FLAGS="$pie -fprofile-arcs -ftest-coverage" \
     -DUSE_COVERAGE=ON
 else
   set -g FULLARGS $FULLARGS \
@@ -68,12 +68,12 @@ else
 
   if test "$MAINTAINER" = "On"
     set -g FULLARGS $FULLARGS \
-     -DCMAKE_C_FLAGS="$pie -fno-stack-protector" \
-     -DCMAKE_CXX_FLAGS="$pie -fno-stack-protector"
+     -DCMAKE_C_FLAGS="$pie" \
+     -DCMAKE_CXX_FLAGS="$pie"
   else
     set -g FULLARGS $FULLARGS \
-     -DCMAKE_C_FLAGS="$pie $inline -fno-stack-protector" \
-     -DCMAKE_CXX_FLAGS="$pie $inline -fno-stack-protector"
+     -DCMAKE_C_FLAGS="$pie $inline" \
+     -DCMAKE_CXX_FLAGS="$pie $inline"
   end
 end
 

--- a/scripts/buildArangoDB6.fish
+++ b/scripts/buildArangoDB6.fish
@@ -48,10 +48,10 @@ set -g FULLARGS $argv \
 
 if test "$MAINTAINER" = "On"
   set -g FULLARGS $FULLARGS \
-    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie -fno-stack-protector"
+    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie"
 else
   set -g FULLARGS $FULLARGS \
-    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie $inline -fno-stack-protector" \
+    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie $inline" \
     -DUSE_CATCH_TESTS=Off \
     -DUSE_GOOGLE_TESTS=Off
 end
@@ -81,7 +81,7 @@ if test "$SAN" = "On"
    -DCMAKE_CXX_FLAGS="-pthread $SANITIZERS -fno-sanitize=vptr -fno-sanitize=alignment" \
    -DBASE_LIBS="-pthread"
 else if test "$COVERAGE" = "On"
-  echo "COVERAGE is not support in this environment!"
+  echo "COVERAGE is not supported in this environment!"
   exit 1
 else
   set -g FULLARGS $FULLARGS \
@@ -89,12 +89,12 @@ else
 
   if test "$MAINTAINER" = "On"
     set -g FULLARGS $FULLARGS \
-     -DCMAKE_C_FLAGS="$pie -fno-stack-protector" \
-     -DCMAKE_CXX_FLAGS="$pie -fno-stack-protector"
+     -DCMAKE_C_FLAGS="$pie" \
+     -DCMAKE_CXX_FLAGS="$pie"
   else
     set -g FULLARGS $FULLARGS \
-     -DCMAKE_C_FLAGS="$pie $inline -fno-stack-protector" \
-     -DCMAKE_CXX_FLAGS="$pie $inline -fno-stack-protector"
+     -DCMAKE_C_FLAGS="$pie $inline" \
+     -DCMAKE_CXX_FLAGS="$pie $inline"
   end
 end
 

--- a/scripts/buildArangoDB7.fish
+++ b/scripts/buildArangoDB7.fish
@@ -47,10 +47,10 @@ set -g FULLARGS $argv \
 
 if test "$MAINTAINER" = "On"
   set -g FULLARGS $FULLARGS \
-    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie -fno-stack-protector"
+    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie"
 else
   set -g FULLARGS $FULLARGS \
-    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie $inline -fno-stack-protector" \
+    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id $pie $inline" \
     -DUSE_CATCH_TESTS=Off \
     -DUSE_GOOGLE_TESTS=Off
 end
@@ -88,12 +88,12 @@ else
 
   if test "$MAINTAINER" = "On"
     set -g FULLARGS $FULLARGS \
-     -DCMAKE_C_FLAGS="$pie -fno-stack-protector" \
-     -DCMAKE_CXX_FLAGS="$pie -fno-stack-protector"
+     -DCMAKE_C_FLAGS="$pie" \
+     -DCMAKE_CXX_FLAGS="$pie"
   else
     set -g FULLARGS $FULLARGS \
-     -DCMAKE_C_FLAGS="$pie $inline -fno-stack-protector" \
-     -DCMAKE_CXX_FLAGS="$pie $inline -fno-stack-protector"
+     -DCMAKE_C_FLAGS="$pie $inline" \
+     -DCMAKE_CXX_FLAGS="$pie $inline"
   end
 end
 


### PR DESCRIPTION
Removes compile option -fno-stack-protector, which is potentially not needed anymore. This can slightly simplify the build process.

ArangoDB PR: https://github.com/arangodb/arangodb/pull/19464
Performance test run: https://jenkins.arangodb.biz/view/Performance/job/perf-simple-branch/96/