### PR TITLE
Bug fix/macos only arangotools

### DIFF
--- a/helper.fish
+++ b/helper.fish
@@ -746,7 +746,7 @@ function prepareInstall
   pushd $path
   and if test $PACKAGE_STRIP = All
     strip usr/bin/{arangobench,arangodump,arangoexport,arangoimport,arangorestore,arangosh,arangovpack}
-    if test "$ARANGODB_VERSION_MAJOR" -eq 3; and test "$ARANGODB_VERSION_MINOR" -le 10; and test $PLATFORM = "darwin"
+    if test "$ARANGODB_VERSION_MAJOR" -eq 3; and test "$ARANGODB_VERSION_MINOR" -le 10; and test $PLATFORM = "darwin"; or test $PLATFORM = "linux"
       strip usr/sbin/arangod
     end
   else if test $PACKAGE_STRIP = ExceptArangod

--- a/helper.mac.fish
+++ b/helper.mac.fish
@@ -1,3 +1,4 @@
+set -gx SCRIPTSDIR $WORKDIR/scripts
 set -gx PLATFORM darwin
 set -gx UID (id -u)
 set -gx GID (id -g)
@@ -509,7 +510,7 @@ end
 
 function setupPackaging
   if test "$ARANGODB_VERSION_MAJOR" -eq 3; and test "$ARANGODB_VERSION_MINOR" -le 10
-    set -xg PACKAGING_OPTIONS "-DPACKAGING=Bundle -DPACKAGE_TARGET_DIR=$INNERWORKDIR -DTHIRDPARTY_BIN=$WORKDIR/work/$THIRDPARTY_BIN/arangodb"    
+    set -xg PACKAGING_OPTIONS "-DPACKAGING=Bundle -DPACKAGE_TARGET_DIR=$INNERWORKDIR -DTHIRDPARTY_BIN=$WORKDIR/work/$THIRDPARTY_BIN/arangodb"
     if test "$ENTERPRISEEDITION" = "On"
       if test "$USE_RCLONE" = "true"
         set -gx THIRDPARTY_SBIN_LIST "$THIRDPARTY_SBIN_LIST\;$WORKDIR/work/$THIRDPARTY_SBIN/rclone-arangodb"

--- a/helper.mac.fish
+++ b/helper.mac.fish
@@ -1,4 +1,3 @@
-set -gx SCRIPTSDIR $WORKDIR/scripts
 set -gx PLATFORM darwin
 set -gx UID (id -u)
 set -gx GID (id -g)
@@ -396,6 +395,7 @@ function switchBranches
   and findDefaultArchitecture
   and findRequiredCompiler
   and findUseARM
+  and findArangoDBVersion
 end
 
 function clearWorkdir
@@ -493,17 +493,51 @@ function downloadSyncer
   and convertSItoJSON
 end
 
+function setupComponents
+  cleanupThirdParty
+  if test "$ARANGODB_VERSION_MAJOR" -eq 3; and test "$ARANGODB_VERSION_MINOR" -le 10
+    downloadStarter
+    and set -gx THIRDPARTY_SBIN_LIST $WORKDIR/work/$THIRDPARTY_SBIN/arangosync
+    and downloadSyncer
+    and copyRclone "macos"
+  else
+    set -xg USE_RCLONE false
+  end
+
+  return 0
+end
+
+function setupPackaging
+  if test "$ARANGODB_VERSION_MAJOR" -eq 3; and test "$ARANGODB_VERSION_MINOR" -le 10
+    set -xg PACKAGING_OPTIONS "-DPACKAGING=Bundle -DPACKAGE_TARGET_DIR=$INNERWORKDIR -DTHIRDPARTY_BIN=$WORKDIR/work/$THIRDPARTY_BIN/arangodb"    
+    if test "$ENTERPRISEEDITION" = "On"
+      if test "$USE_RCLONE" = "true"
+        set -gx THIRDPARTY_SBIN_LIST "$THIRDPARTY_SBIN_LIST\;$WORKDIR/work/$THIRDPARTY_SBIN/rclone-arangodb"
+      end
+      set -xg PACKAGING_OPTIONS "$PACKAGING_OPTIONS -DTHIRDPARTY_SBIN=$THIRDPARTY_SBIN_LIST"
+    end
+  else
+    set -xg PACKAGING_OPTIONS ""
+  end
+
+  return 0
+end
+
 function buildPackage
   # This assumes that a build has already happened
 
   if test "$ENTERPRISEEDITION" = "On"
-    echo Building enterprise edition MacOs bundle...
+    echo Building enterprise edition macOs bundle...
   else
-    echo Building community edition MacOs bundle...
+    echo Building community edition macOs bundle...
   end
 
-  runLocal $SCRIPTSDIR/buildMacOsPackage.fish $ARANGODB_PACKAGES
-  and buildTarGzPackage
+  if test "$ARANGODB_VERSION_MAJOR" -eq 3; and test "$ARANGODB_VERSION_MINOR" -le 10
+    runLocal $SCRIPTSDIR/buildMacOsPackage.fish $ARANGODB_PACKAGES
+    and buildTarGzPackage
+  else
+    buildTarGzPackage
+  end
 end
 
 function cleanupThirdParty
@@ -524,20 +558,9 @@ function buildEnterprisePackage
   and releaseMode
   and enterprise
   and set -xg NOSTRIP 1
-  and cleanupThirdParty
-  and set -gx THIRDPARTY_SBIN_LIST $WORKDIR/work/$THIRDPARTY_SBIN/arangosync
-  and downloadStarter
-  and downloadSyncer
-  and copyRclone "macos"
-  and if test "$USE_RCLONE" = "true"
-    set -gx THIRDPARTY_SBIN_LIST "$THIRDPARTY_SBIN_LIST\;$WORKDIR/work/$THIRDPARTY_SBIN/rclone-arangodb"
-  end
-  and buildArangoDB \
-      -DPACKAGING=Bundle \
-      -DPACKAGE_TARGET_DIR=$INNERWORKDIR \
-      -DTHIRDPARTY_SBIN=$THIRDPARTY_SBIN_LIST \
-      -DTHIRDPARTY_BIN=$WORKDIR/work/$THIRDPARTY_BIN/arangodb \
-      -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX
+  and setupComponents
+  and setupPackaging
+  and buildArangoDB $PACKAGING_OPTIONS -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX
   and buildPackage
 
   if test $status != 0
@@ -554,13 +577,9 @@ function buildCommunityPackage
   and releaseMode
   and community
   and set -xg NOSTRIP 1
-  and cleanupThirdParty
-  and downloadStarter
-  and buildArangoDB \
-      -DPACKAGING=Bundle \
-      -DPACKAGE_TARGET_DIR=$INNERWORKDIR \
-      -DTHIRDPARTY_BIN=$WORKDIR/work/$THIRDPARTY_BIN/arangodb \
-      -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX
+  and setupComponents
+  and setupPackaging
+  and buildArangoDB $PACKAGING_OPTIONS -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX
   and buildPackage
 
   if test $status != 0
@@ -570,18 +589,30 @@ function buildCommunityPackage
 end
 
 function buildTarGzPackage
+  if test "$ARANGODB_VERSION_MAJOR" -eq 3; and test "$ARANGODB_VERSION_MINOR" -ge 11
+    set -xg MAKE_INSTALL_COMPONENTS '-C client-tools'
+  else
+    set -xg MAKE_INSTALL_COMPONENTS ""
+  end
   pushd $INNERWORKDIR/ArangoDB/build
+  echo (pwd)
+  echo (ls -l client-tools)
   and rm -rf install
-  and make install DESTDIR=install
+  and echo "make $MAKE_INSTALL_COMPONENTS install DESTDIR="(pwd)"/install"
+  and eval make $MAKE_INSTALL_COMPONENTS install VERBOSE=1 DESTDIR=(pwd)/install
   and makeJsSha1Sum (pwd)/install/opt/arangodb/share/arangodb3/js
   and if test "$ENTERPRISEEDITION" = "On"
-        pushd install/opt/arangodb/bin
-        ln -s ../sbin/arangosync
-        popd
+        if test "$ARANGODB_VERSION_MAJOR" -eq 3; and test "$ARANGODB_VERSION_MINOR" -le 10
+          pushd install/opt/arangodb/bin
+          ln -s ../sbin/arangosync
+          popd
+        end
       end
   and mkdir -p install/usr
   and mv install/opt/arangodb/bin install/usr
-  and mv install/opt/arangodb/sbin install/usr
+  and if test "$ARANGODB_VERSION_MAJOR" -eq 3; and test "$ARANGODB_VERSION_MINOR" -le 10
+        mv install/opt/arangodb/sbin install/usr
+      end
   and mv install/opt/arangodb/share install/usr
   and mv install/opt/arangodb/etc install
   and rm -rf install/opt

--- a/jenkins/helper/test_launch_controller.py
+++ b/jenkins/helper/test_launch_controller.py
@@ -96,6 +96,7 @@ known_flags = {
     "ldap": "ldap",
     "enterprise": "this tests is only executed with the enterprise version",
     "!windows": "test is excluded from ps1 output",
+    "!circleci": "test is excluded on CircleCI",
     "!mac": "test is excluded when launched on MacOS",
     "!arm": "test is excluded when launched on Arm Linux/MacOS hosts",
     "!coverage": "test is excluded when coverage scenario are ran",

--- a/scripts/buildMacOs.fish
+++ b/scripts/buildMacOs.fish
@@ -37,13 +37,18 @@ set -xg FULLARGS $argv \
  -DUSE_ENTERPRISE=$ENTERPRISEEDITION \
  -DUSE_JEMALLOC=$JEMALLOC_OSKAR \
  -DCMAKE_SKIP_RPATH=On \
- -DPACKAGING=Bundle \
  -DPACKAGE_TARGET_DIR=$INNERWORKDIR \
  -DOPENSSL_USE_STATIC_LIBS=$OPENSSL_USE_STATIC_LIBS \
  -DOPENSSL_ROOT_DIR=$OPENSSL_ROOT_DIR \
  -DCMAKE_OSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET \
  -DUSE_STRICT_OPENSSL_VERSION=$USE_STRICT_OPENSSL \
  -DBUILD_REPO_INFO=$BUILD_REPO_INFO
+
+if test "$ARANGODB_VERSION_MAJOR" -eq 3; and test "$ARANGODB_VERSION_MINOR" -ge 11
+  set -xg MAKE_TARGETS client-tools
+else
+  set -xg FULLARGS "$FULLARGS -DPACKAGING=Bundle"
+end
 
 setupCcacheBinPath macos
 and setupCcache macos
@@ -59,7 +64,7 @@ and if test "$SKIP_MAKE" = "On"
   echo "Finished cmake at "(date)", skipping build"
 else
   echo "Finished cmake at "(date)", now starting build"
-  and runMake
+  and runMake $MAKE_TARGETS
   and TT_make
   and echo "Finished at "(date)
   and shutdownCcache

--- a/scripts/makeArangoDB.fish
+++ b/scripts/makeArangoDB.fish
@@ -12,9 +12,13 @@ ccache -M $CCACHE_MAXSIZE
 cd $INNERWORKDIR/ArangoDB/build
 or exit $status
 
+if test "$ARANGODB_VERSION_MAJOR" -eq 3; and test "$ARANGODB_VERSION_MINOR" -ge 11; test "$PLATFORM" = "darwin"
+  set -xg MAKE_TARGETS client-tools
+end
+
 set -l GOLD
 if test "$PLATFORM" = "linux"
   set GOLD = -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold  -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=gold
 end
 
-nice make -j$PARALLELISM $argv
+nice make -j$PARALLELISM $MAKE_TARGETS $argv


### PR DESCRIPTION
This PR allows (for macOS):
- build and install only `client-tools` target for 3.11+ versions
- build and install whole arangodb target for 3.10- versions
- package only TAR.GZ client tools for 3.11+ versions
- package DMG for server and TAR.GZ client tools for 3.10- versions