### PR TITLE
OpenSSL 3.0.13 and 3.1.5, OpenLDAP 2.6.7

### DIFF
--- a/containers/buildAlpine6.docker/Dockerfile
+++ b/containers/buildAlpine6.docker/Dockerfile
@@ -16,16 +16,16 @@ COPY ./tools/install-poll.sh /tools/
 RUN /tools/install-poll.sh
 
 COPY ./tools/install-openssl.sh /tools/
-RUN [ "/tools/install-openssl.sh", "3.0", ".12" ]
+RUN [ "/tools/install-openssl.sh", "3.0", ".13" ]
        
 COPY ./tools/install-openldap.sh /tools/
-RUN [ "/tools/install-openldap.sh", "3.0.12" ]
+RUN [ "/tools/install-openldap.sh", "3.0.13" ]
 
 COPY ./tools/install-openssl.sh /tools/
-RUN [ "/tools/install-openssl.sh", "3.1", ".4" ]
+RUN [ "/tools/install-openssl.sh", "3.1", ".5" ]
 
 COPY ./tools/install-openldap.sh /tools/
-RUN [ "/tools/install-openldap.sh", "3.1.4" ]
+RUN [ "/tools/install-openldap.sh", "3.1.5" ]
 
 RUN curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-${ARCH}-unknown-linux-musl.tar.gz | tar xvz -C /tmp && mv /tmp/sccache-v0.2.15-${ARCH}-unknown-linux-musl/sccache /usr/bin/sccache && chmod +x /usr/bin/sccache && rm -rf /tmp/sccache-v0.2.15-${ARCH}-unknown-linux-musl
 

--- a/containers/buildAlpine6.docker/tools/install-openldap.sh
+++ b/containers/buildAlpine6.docker/tools/install-openldap.sh
@@ -6,7 +6,7 @@ test -n "$OPENSSLVERSION"
 export OPENSSLPATH=`echo $OPENSSLVERSION | sed 's/\([a-zA-Z]$\|\.[0-9]*$\)//g'`
 
 # Compile openldap library:
-export OPENLDAPVERSION=2.6.6
+export OPENLDAPVERSION=2.6.7
 cd /tmp
 curl -O ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/openldap-$OPENLDAPVERSION.tgz
 tar xzf openldap-$OPENLDAPVERSION.tgz

--- a/containers/buildUbuntu6.docker/Dockerfile
+++ b/containers/buildUbuntu6.docker/Dockerfile
@@ -20,9 +20,9 @@ RUN curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache
 
 COPY ./tools/* /tools/
 
-RUN [ "/tools/install.sh", "3.0", ".12" ]
+RUN [ "/tools/install.sh", "3.0", ".13" ]
 
-RUN [ "/tools/install.sh", "3.1", ".4" ]
+RUN [ "/tools/install.sh", "3.1", ".5" ]
 
 COPY ./scripts /scripts
 

--- a/containers/buildUbuntu6.docker/tools/install.sh
+++ b/containers/buildUbuntu6.docker/tools/install.sh
@@ -36,7 +36,7 @@ cd /tmp
 rm -rf openssl-$OPENSSLVERSION.tar.gz openssl-$OPENSSLVERSION
 
 # Compile openldap library:
-export OPENLDAPVERSION=2.6.6
+export OPENLDAPVERSION=2.6.7
 cd /tmp
 curl -O ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/openldap-$OPENLDAPVERSION.tgz
 tar xzf openldap-$OPENLDAPVERSION.tgz

--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -22,7 +22,7 @@ else
 end
 
 set -gx UBUNTUBUILDIMAGE6_NAME arangodb/ubuntubuildarangodb6-$ARCH
-set -gx UBUNTUBUILDIMAGE6_TAG 13
+set -gx UBUNTUBUILDIMAGE6_TAG 14
 set -gx UBUNTUBUILDIMAGE6 $UBUNTUBUILDIMAGE6_NAME:$UBUNTUBUILDIMAGE6_TAG
 
 set -gx UBUNTUBUILDIMAGE_DEVEL_NAME arangodb/ubuntubuildarangodb-devel
@@ -33,7 +33,7 @@ set -gx UBUNTUPACKAGINGIMAGE arangodb/ubuntupackagearangodb-$ARCH:1
 set -gx UBUNTUPACKAGINGIMAGE2 arangodb/ubuntupackagearangodb-$ARCH:2
 
 set -gx ALPINEBUILDIMAGE6_NAME arangodb/alpinebuildarangodb6-$ARCH
-set -gx ALPINEBUILDIMAGE6_TAG 12
+set -gx ALPINEBUILDIMAGE6_TAG 13
 set -gx ALPINEBUILDIMAGE6 $ALPINEBUILDIMAGE6_NAME:$ALPINEBUILDIMAGE6_TAG
 
 set -gx ALPINEPERFBUILDIMAGE1_NAME arangodb/alpineperfbuildimage1-$ARCH


### PR DESCRIPTION
Update OpenSSL to 3.0.13 and 3.1.5 and OpenLDAP to 2.6.7 within 3.10 and 3.11 build containers.

3.10 PR: https://github.com/arangodb/arangodb/pull/20622
3.11 PR: https://github.com/arangodb/arangodb/pull/20623

AWS (Linux) AMIs and GCE (Windows) template must be updated after merge!