### PR TITLE
ubi-minimal:latest for 3.10 and 3.12 (devel)

### DIFF
--- a/containers/arangodb310ubi.docker/Dockerfile
+++ b/containers/arangodb310ubi.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 MAINTAINER Frank Celler <info@arangodb.com>
 
 RUN microdnf update -y && rm -rf /var/cache/yum
@@ -25,12 +25,12 @@ ADD ./LICENSE /licenses/LICENSE
 ENV GLIBCXX_FORCE_NEW=1
 
 RUN microdnf install gpg wget binutils && \
-    curl -L -O http://mirror.centos.org/centos/8-stream/BaseOS/$(uname -p)/os/Packages/numactl-libs-2.0.12-13.el8.$(uname -p).rpm && \
-    rpm -i numactl-libs-2.0.12-13.el8.$(uname -p).rpm && \
-    rm numactl-libs-2.0.12-13.el8.$(uname -p).rpm && \
-    curl -L -O http://mirror.centos.org/centos/8-stream/BaseOS/$(uname -p)/os/Packages/numactl-2.0.12-13.el8.$(uname -p).rpm && \
-    rpm -i numactl-2.0.12-13.el8.$(uname -p).rpm && \
-    rm numactl-2.0.12-13.el8.$(uname -p).rpm && \
+    curl -L -O http://mirror.centos.org/centos/8-stream/BaseOS/$(uname -p)/os/Packages/numactl-libs-2.0.16-4.el8.$(uname -p).rpm && \
+    rpm -i numactl-libs-2.0.16-4.el8.$(uname -p).rpm && \
+    rm numactl-libs-2.0.16-4.el8.$(uname -p).rpm && \
+    curl -L -O http://mirror.centos.org/centos/8-stream/BaseOS/$(uname -p)/os/Packages/numactl-2.0.16-4.el8.$(uname -p).rpm && \
+    rpm -i numactl-2.0.16-4.el8.$(uname -p).rpm && \
+    rm numactl-2.0.16-4.el8.$(uname -p).rpm && \
     microdnf clean all
 
 ADD install.tar.gz /

--- a/containers/arangodb312ubi.docker/Dockerfile
+++ b/containers/arangodb312ubi.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 MAINTAINER Frank Celler <info@arangodb.com>
 
 RUN microdnf update -y && rm -rf /var/cache/yum
@@ -23,12 +23,12 @@ LABEL name="$name" \
 ADD ./LICENSE /licenses/LICENSE
 
 RUN microdnf install gpg wget binutils && \
-    curl -L -O http://mirror.centos.org/centos/8-stream/BaseOS/$(uname -p)/os/Packages/numactl-libs-2.0.12-13.el8.$(uname -p).rpm && \
-    rpm -i numactl-libs-2.0.12-13.el8.$(uname -p).rpm && \
-    rm numactl-libs-2.0.12-13.el8.$(uname -p).rpm && \
-    curl -L -O http://mirror.centos.org/centos/8-stream/BaseOS/$(uname -p)/os/Packages/numactl-2.0.12-13.el8.$(uname -p).rpm && \
-    rpm -i numactl-2.0.12-13.el8.$(uname -p).rpm && \
-    rm numactl-2.0.12-13.el8.$(uname -p).rpm && \
+    curl -L -O http://mirror.centos.org/centos/8-stream/BaseOS/$(uname -p)/os/Packages/numactl-libs-2.0.16-4.el8.$(uname -p).rpm && \
+    rpm -i numactl-libs-2.0.16-4.el8.$(uname -p).rpm && \
+    rm numactl-libs-2.0.16-4.el8.$(uname -p).rpm && \
+    curl -L -O http://mirror.centos.org/centos/8-stream/BaseOS/$(uname -p)/os/Packages/numactl-2.0.16-4.el8.$(uname -p).rpm && \
+    rpm -i numactl-2.0.16-4.el8.$(uname -p).rpm && \
+    rm numactl-2.0.16-4.el8.$(uname -p).rpm && \
     microdnf clean all
 
 ADD install.tar.gz /

--- a/containers/arangodbDevelubi.docker/Dockerfile
+++ b/containers/arangodbDevelubi.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 MAINTAINER Frank Celler <info@arangodb.com>
 
 RUN microdnf update -y && rm -rf /var/cache/yum
@@ -23,12 +23,12 @@ LABEL name="$name" \
 ADD ./LICENSE /licenses/LICENSE
 
 RUN microdnf install gpg wget binutils && \
-    curl -L -O http://mirror.centos.org/centos/8-stream/BaseOS/$(uname -p)/os/Packages/numactl-libs-2.0.12-13.el8.$(uname -p).rpm && \
-    rpm -i numactl-libs-2.0.12-13.el8.$(uname -p).rpm && \
-    rm numactl-libs-2.0.12-13.el8.$(uname -p).rpm && \
-    curl -L -O http://mirror.centos.org/centos/8-stream/BaseOS/$(uname -p)/os/Packages/numactl-2.0.12-13.el8.$(uname -p).rpm && \
-    rpm -i numactl-2.0.12-13.el8.$(uname -p).rpm && \
-    rm numactl-2.0.12-13.el8.$(uname -p).rpm && \
+    curl -L -O http://mirror.centos.org/centos/8-stream/BaseOS/$(uname -p)/os/Packages/numactl-libs-2.0.16-4.el8.$(uname -p).rpm && \
+    rpm -i numactl-libs-2.0.16-4.el8.$(uname -p).rpm && \
+    rm numactl-libs-2.0.16-4.el8.$(uname -p).rpm && \
+    curl -L -O http://mirror.centos.org/centos/8-stream/BaseOS/$(uname -p)/os/Packages/numactl-2.0.16-4.el8.$(uname -p).rpm && \
+    rpm -i numactl-2.0.16-4.el8.$(uname -p).rpm && \
+    rm numactl-2.0.16-4.el8.$(uname -p).rpm && \
     microdnf clean all
 
 ADD install.tar.gz /


### PR DESCRIPTION
Use ubi-minimal:latest for 3.10 and 3.12 (devel) UBI images and update NUMA tools.