### PR TITLE
Propagate server parameters to Docker

### DIFF
--- a/containers/arangodb311alpine.docker/entrypoint.sh
+++ b/containers/arangodb311alpine.docker/entrypoint.sh
@@ -85,7 +85,7 @@ if [ "$1" = 'arangod' ]; then
 
         echo "Initializing database...Hang on..."
 
-        $NUMACTL arangod --config /tmp/arangod.conf \
+        $NUMACTL arangod "$@" --config /tmp/arangod.conf \
                 --server.endpoint tcp://127.0.0.1:$ARANGO_INIT_PORT \
                 --server.authentication false \
 		--log.file /tmp/init-log \

--- a/containers/arangodb311deb.docker/entrypoint.sh
+++ b/containers/arangodb311deb.docker/entrypoint.sh
@@ -85,7 +85,7 @@ if [ "$1" = 'arangod' ]; then
 
         echo "Initializing database...Hang on..."
 
-        $NUMACTL arangod $@" --config /tmp/arangod.conf \
+        $NUMACTL arangod "$@" --config /tmp/arangod.conf \
                 --server.endpoint tcp://127.0.0.1:$ARANGO_INIT_PORT \
                 --server.authentication false \
 		--log.file /tmp/init-log \

--- a/containers/arangodb311deb.docker/entrypoint.sh
+++ b/containers/arangodb311deb.docker/entrypoint.sh
@@ -85,7 +85,7 @@ if [ "$1" = 'arangod' ]; then
 
         echo "Initializing database...Hang on..."
 
-        $NUMACTL arangod --config /tmp/arangod.conf \
+        $NUMACTL arangod $@" --config /tmp/arangod.conf \
                 --server.endpoint tcp://127.0.0.1:$ARANGO_INIT_PORT \
                 --server.authentication false \
 		--log.file /tmp/init-log \

--- a/containers/arangodb311ubi.docker/entrypoint.sh
+++ b/containers/arangodb311ubi.docker/entrypoint.sh
@@ -85,7 +85,7 @@ if [ "$1" = 'arangod' ]; then
 
         echo "Initializing database...Hang on..."
 
-        $NUMACTL arangod --config /tmp/arangod.conf \
+        $NUMACTL arangod "$@" --config /tmp/arangod.conf \
                 --server.endpoint tcp://127.0.0.1:$ARANGO_INIT_PORT \
                 --server.authentication false \
 		--log.file /tmp/init-log \

--- a/containers/arangodb312alpine.docker/entrypoint.sh
+++ b/containers/arangodb312alpine.docker/entrypoint.sh
@@ -85,7 +85,7 @@ if [ "$1" = 'arangod' ]; then
 
         echo "Initializing database...Hang on..."
 
-        $NUMACTL arangod --config /tmp/arangod.conf \
+        $NUMACTL arangod "$@" --config /tmp/arangod.conf \
                 --server.endpoint tcp://127.0.0.1:$ARANGO_INIT_PORT \
                 --server.authentication false \
 		--log.file /tmp/init-log \

--- a/containers/arangodb312deb.docker/entrypoint.sh
+++ b/containers/arangodb312deb.docker/entrypoint.sh
@@ -85,7 +85,7 @@ if [ "$1" = 'arangod' ]; then
 
         echo "Initializing database...Hang on..."
 
-        $NUMACTL arangod --config /tmp/arangod.conf \
+        $NUMACTL arangod "$@" --config /tmp/arangod.conf \
                 --server.endpoint tcp://127.0.0.1:$ARANGO_INIT_PORT \
                 --server.authentication false \
 		--log.file /tmp/init-log \

--- a/containers/arangodb312ubi.docker/entrypoint.sh
+++ b/containers/arangodb312ubi.docker/entrypoint.sh
@@ -85,7 +85,7 @@ if [ "$1" = 'arangod' ]; then
 
         echo "Initializing database...Hang on..."
 
-        $NUMACTL arangod --config /tmp/arangod.conf \
+        $NUMACTL arangod "$@" --config /tmp/arangod.conf \
                 --server.endpoint tcp://127.0.0.1:$ARANGO_INIT_PORT \
                 --server.authentication false \
 		--log.file /tmp/init-log \

--- a/containers/arangodbDevelalpine.docker/entrypoint.sh
+++ b/containers/arangodbDevelalpine.docker/entrypoint.sh
@@ -85,7 +85,7 @@ if [ "$1" = 'arangod' ]; then
 
         echo "Initializing database...Hang on..."
 
-        $NUMACTL arangod --config /tmp/arangod.conf \
+        $NUMACTL arangod "$@" --config /tmp/arangod.conf \
                 --server.endpoint tcp://127.0.0.1:$ARANGO_INIT_PORT \
                 --server.authentication false \
 		--log.file /tmp/init-log \

--- a/containers/arangodbDeveldeb.docker/entrypoint.sh
+++ b/containers/arangodbDeveldeb.docker/entrypoint.sh
@@ -85,7 +85,7 @@ if [ "$1" = 'arangod' ]; then
 
         echo "Initializing database...Hang on..."
 
-        $NUMACTL arangod --config /tmp/arangod.conf \
+        $NUMACTL arangod "$@" --config /tmp/arangod.conf \
                 --server.endpoint tcp://127.0.0.1:$ARANGO_INIT_PORT \
                 --server.authentication false \
 		--log.file /tmp/init-log \

--- a/containers/arangodbDevelubi.docker/entrypoint.sh
+++ b/containers/arangodbDevelubi.docker/entrypoint.sh
@@ -85,7 +85,7 @@ if [ "$1" = 'arangod' ]; then
 
         echo "Initializing database...Hang on..."
 
-        $NUMACTL arangod --config /tmp/arangod.conf \
+        $NUMACTL arangod "$@" --config /tmp/arangod.conf \
                 --server.endpoint tcp://127.0.0.1:$ARANGO_INIT_PORT \
                 --server.authentication false \
 		--log.file /tmp/init-log \


### PR DESCRIPTION
This PR fixes the wrong behavior described in https://arangodb.atlassian.net/browse/MDS-1224.
As for now all parameters will be used during init stage in Docker.