### PR TITLE
Use legacy icudtl.dat tables from 3.11 [BTS-1989]

### DIFF
--- a/debian/3.12/common/rules
+++ b/debian/3.12/common/rules
@@ -20,7 +20,7 @@ override_dh_auto_install:
 	cp debian/arangodb3.init debian/@EDITION@/etc/init.d/arangodb3
 	cd build/install ; for i in arangobench arangodump arangoexport arangoimport arangoinspect arangorestore arangosh arangovpack foxx-manager; do cp -a --parents etc/arangodb3/$$i.conf usr/bin/$$i ../../debian/@EDITION@-client; done
 	cd build/install ; for i in arangoimp; do cp -a --parents usr/bin/$$i ../../debian/@EDITION@-client; done
-	cd build/install ; cp -a --parents usr/share/arangodb3/icudtl.dat ../../debian/@EDITION@-client
+	cd build/install ; cp -a --parents usr/share/arangodb3/icudtl*.dat ../../debian/@EDITION@-client
 	cd build/install ; if test -d usr/share/arangodb3/js/common; then cp -a --parents usr/share/arangodb3/js/common usr/share/arangodb3/js/client usr/share/arangodb3/js/node ../../debian/@EDITION@-client; else cp -a --parents usr/share/arangodb3/js/*/common usr/share/arangodb3/js/*/client usr/share/arangodb3/js/*/node ../../debian/@EDITION@-client; fi
 	cd build/install ; if test -x usr/bin/arangobackup ; then cp -a --parents etc/arangodb3/arangobackup.conf usr/bin/arangobackup ../../debian/@EDITION@-client ; fi
 

--- a/debian/default/common/rules
+++ b/debian/default/common/rules
@@ -20,7 +20,7 @@ override_dh_auto_install:
 	cp debian/arangodb3.init debian/@EDITION@/etc/init.d/arangodb3
 	cd build/install ; for i in arangobench arangodump arangoexport arangoimport arangoinspect arangorestore arangosh arangovpack foxx-manager; do cp -a --parents etc/arangodb3/$$i.conf usr/bin/$$i ../../debian/@EDITION@-client; done
 	cd build/install ; for i in arangoimp; do cp -a --parents usr/bin/$$i ../../debian/@EDITION@-client; done
-	cd build/install ; cp -a --parents usr/share/arangodb3/icudtl.dat ../../debian/@EDITION@-client
+	cd build/install ; cp -a --parents usr/share/arangodb3/icudtl*.dat ../../debian/@EDITION@-client
 	cd build/install ; if test -d usr/share/arangodb3/js/common; then cp -a --parents usr/share/arangodb3/js/common usr/share/arangodb3/js/client usr/share/arangodb3/js/node ../../debian/@EDITION@-client; else cp -a --parents usr/share/arangodb3/js/*/common usr/share/arangodb3/js/*/client usr/share/arangodb3/js/*/node ../../debian/@EDITION@-client; fi
 	cd build/install ; if test -x usr/bin/arangobackup ; then cp -a --parents etc/arangodb3/arangobackup.conf usr/bin/arangobackup ../../debian/@EDITION@-client ; fi
 

--- a/rpm/3.12/arangodb3.spec.in
+++ b/rpm/3.12/arangodb3.spec.in
@@ -163,7 +163,7 @@ rmdir /tmp/sbin /tmp/bin
 %{_datadir}/arangodb3/js@JS_DIR@/common
 %{_datadir}/arangodb3/js@JS_DIR@/client
 %{_datadir}/arangodb3/js@JS_DIR@/node
-%{_datadir}/arangodb3/icudtl.dat
+%{_datadir}/arangodb3/icudtl*.dat
 
 ## -----------------------------------------------------------------------------
 ## --SECTION--                                                         changelog

--- a/rpm/3.12/arangodb3e.spec.in
+++ b/rpm/3.12/arangodb3e.spec.in
@@ -165,7 +165,7 @@ rmdir /tmp/sbin /tmp/bin
 %{_datadir}/arangodb3/js@JS_DIR@/common
 %{_datadir}/arangodb3/js@JS_DIR@/client
 %{_datadir}/arangodb3/js@JS_DIR@/node
-%{_datadir}/arangodb3/icudtl.dat
+%{_datadir}/arangodb3/icudtl*.dat
 
 ## -----------------------------------------------------------------------------
 ## --SECTION--                                                         changelog

--- a/rpm/default/arangodb3.spec.in
+++ b/rpm/default/arangodb3.spec.in
@@ -163,7 +163,7 @@ rmdir /tmp/sbin /tmp/bin
 %{_datadir}/arangodb3/js@JS_DIR@/common
 %{_datadir}/arangodb3/js@JS_DIR@/client
 %{_datadir}/arangodb3/js@JS_DIR@/node
-%{_datadir}/arangodb3/icudtl.dat
+%{_datadir}/arangodb3/icudtl*.dat
 
 ## -----------------------------------------------------------------------------
 ## --SECTION--                                                         changelog

--- a/rpm/default/arangodb3e.spec.in
+++ b/rpm/default/arangodb3e.spec.in
@@ -165,7 +165,7 @@ rmdir /tmp/sbin /tmp/bin
 %{_datadir}/arangodb3/js@JS_DIR@/common
 %{_datadir}/arangodb3/js@JS_DIR@/client
 %{_datadir}/arangodb3/js@JS_DIR@/node
-%{_datadir}/arangodb3/icudtl.dat
+%{_datadir}/arangodb3/icudtl*.dat
 
 ## -----------------------------------------------------------------------------
 ## --SECTION--                                                         changelog


### PR DESCRIPTION
Ship icudtl_legacy.dat in 3.12 in client tool packages.
