### PR TITLE
Raise Alpine base to 3.18 for ArangoDB supported images

### DIFF
--- a/containers/arangodb311alpine.docker/Dockerfile
+++ b/containers/arangodb311alpine.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.18
 MAINTAINER Max Neunhoeffer <hackers@arangodb.com>
 
 RUN apk add --no-cache pwgen nodejs numactl numactl-tools

--- a/containers/arangodb312alpine.docker/Dockerfile
+++ b/containers/arangodb312alpine.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.18
 MAINTAINER Max Neunhoeffer <hackers@arangodb.com>
 
 RUN apk add --no-cache pwgen numactl numactl-tools

--- a/containers/arangodbDevelalpine.docker/Dockerfile
+++ b/containers/arangodbDevelalpine.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.18
 MAINTAINER Max Neunhoeffer <hackers@arangodb.com>
 
 RUN apk add --no-cache pwgen numactl numactl-tools


### PR DESCRIPTION
According to https://alpinelinux.org/releases/ currently used Alpine 3.17 is EoL in 2 weeks as of now.

- [x] https://jenkins.arangodb.biz/job/helper-docker-packages/1723/
- [x] https://jenkins.arangodb.biz/job/helper-docker-packages/1724/
- [x] https://jenkins.arangodb.biz/job/arangodb-ANY-components-and-drivers/51/
- [x] https://jenkins.arangodb.biz/job/arangodb-ANY-components-and-drivers/52/