### PR TITLE
chore: add Dependabot configuration for shipping container images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Dependabot configuration for arangodb/oskar.
+# Target: .github/dependabot.yml on the `master` branch.
+# Tracks base-image updates for the customer-shipping ArangoDB container images.
+# Build-toolchain Dockerfiles are intentionally excluded — they're pinned for build reproducibility.
+
+version: 2
+
+updates:
+  - package-ecosystem: "docker"
+    directories:
+      - "/containers/arangodb311alpine.docker"
+      - "/containers/arangodb311deb.docker"
+      - "/containers/arangodb311ubi.docker"
+      - "/containers/arangodb312alpine.docker"
+      - "/containers/arangodb312deb.docker"
+      - "/containers/arangodb312ubi.docker"
+      - "/containers/arangodbDevelalpine.docker"
+      - "/containers/arangodbDeveldeb.docker"
+      - "/containers/arangodbDevelubi.docker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "docker"
+      - "security"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      shipping-images-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to track base-image updates for the customer-shipping ArangoDB container images.

## Scope

Tracks 9 shipping Dockerfile directories:

- `containers/arangodb{311,312,Devel}{alpine,deb,ubi}.docker/`

Build / packaging toolchain images (`buildUbuntu*`, `buildCentos*`, `buildUtils`, `cppcheck`, `oskar.docker`, `sshClient`, `ldap`) are intentionally excluded — they're pinned for reproducibility and automated bumps would risk breaking the build. Happy to add a follow-up for any of these if desired.

## Behavior

- Weekly schedule, Monday 06:00 Europe/Berlin
- Minor + patch updates grouped into one PR per week across all 9 directories
- Open-PR cap of 10
- Conventional Commits prefix (`build`)

## Test plan

- [ ] Merge
- [ ] Trigger manually from Insights → Dependency graph → Dependabot → "Check for updates"
- [ ] Watch the first batch land and tune grouping if needed

Driven by the security / compliance program (supply-chain dependency tracking for ISO 27001, BSI C5, SOC 2).