### PR TITLE
ci(security): enable grype CVE gate by default for stable docker images

### DIFF
--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -1129,6 +1129,24 @@ end
 
 function buildDockerRelease
   echo "building docker release"
+
+  # GA (stable) images must not publish with unreviewed CVEs. Default the
+  # grype gate in validateDockerImageIfNeeded to run-and-block for stable
+  # releases when the operator hasn't already set these explicitly (e.g. via
+  # Jenkins job env), so the check is no longer opt-in for GA publishing.
+  # This only fills in unset values -- any explicit setting (on or off) is
+  # left untouched.
+  if test "$RELEASE_TYPE" = "stable"
+    test -z "$RUN_CVE_CHECKS_FOR_DOCKER_IMAGE"
+    and enableDockerCveCheck
+
+    test -z "$PUBLISH_DOCKER_IMAGE_ONLY_IF_CVE_CHECKS_PASS"
+    and set -xg PUBLISH_DOCKER_IMAGE_ONLY_IF_CVE_CHECKS_PASS 1
+
+    test -z "$CREATE_CVE_REPORT_FOR_DOCKER_IMAGE"
+    and enableCveReport
+  end
+
   sanOff
   and maintainerOff
   and releaseMode

--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -2181,6 +2181,12 @@ function checkDockerImageForCves
   end
   echo "scanning image for CVEs: $image"
   echo "apply specific CVE exclusions list"
+  # rebuild the config per image. applyGrypeIgnores appends, so reusing a
+  # config from an earlier image in the same job (makeDockerRelease scans the
+  # community image and then the enterprise one) leaves two top-level "ignore"
+  # keys, which grype's YAML loader rejects.
+  setupGrype
+  or return 1
   applyGrypeIgnores $image
   or return $status
   if set -q report_file[1]

--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -2147,11 +2147,16 @@ function downloadOrUpdateGrype
     if test $status -eq 0
       echo "Grype is already installed. Updating the CVE database"
       $GRYPE_BIN db update
-      if test $status -eq 0
-        echo "Grype CVE database is updated successfully"
+      if test $status -ne 0
+        echo "Failed to update the Grype CVE database"
+        return 1
       end
-      echo "Failed to update the Grype CVE database"
-      return 1
+      echo "Grype CVE database is updated successfully"
+    else
+      # binary is there but not runnable, clearResults never cleans work/tools
+      echo "Grype at $GRYPE_BIN is not usable, reinstalling"
+      installGrype
+      or return 1
     end
   else
     # grype is not installed


### PR DESCRIPTION
## What

- In `buildDockerRelease`, when `RELEASE_TYPE` is `stable`, default `RUN_CVE_CHECKS_FOR_DOCKER_IMAGE`, `PUBLISH_DOCKER_IMAGE_ONLY_IF_CVE_CHECKS_PASS` and `CREATE_CVE_REPORT_FOR_DOCKER_IMAGE` to on when they are unset. An explicit value, on or off, is left alone.
- `downloadOrUpdateGrype`: the db-update status check was the wrong way round, so an already-installed grype always returned 1, `setupGrype` never ran and `GRYPE_CONF_PATH` stayed unset. A present but unrunnable binary is now reinstalled rather than falling through to a scan that cannot work.
- `checkDockerImageForCves`: call `setupGrype` per image. `applyGrypeIgnores` appends to the config, so the second image scanned in one fish process (`makeDockerRelease` does community then enterprise) got two top-level `ignore` keys, which grype's YAML loader rejects.

## Why

`validateDockerImageIfNeeded` only scans when those variables are set, and nothing in the repo sets them: `helper.fish` defines `enableDockerCveCheck` and `enableCveReport` but nothing calls them. With them unset the guarded `if` is skipped with no `else`, `$status` is still `0` at the following `test $status -ne 0`, and the function returns success. The four release docker jobs push exactly the images `releaseUpdateDockerHub` later copies to the GA `arangodb/arangodb` and `arangodb/enterprise` names, so GA images ship with no CVE check today even though grype, `checkDockerImageForCves` and the ignore list are already in place. Both defects above fail the gate without a CVE present, so arming it without fixing them would block a stable publish for no security reason.

## Notes

- Severity threshold is unchanged: `checkDockerImageForCves` falls back to `high` when `CVE_SEVERITY_THRESHOLD` is unset.
- Preview and nightly builds are unaffected (`jenkins/preview*.fish` set `RELEASE_TYPE=preview`), the multiarch release jobs only push manifests, and `arangodb/*-debug` reaches `buildDockerAny` through `buildDockerDebug` directly.
- Reports land in `work/grype_reports`, which `moveResultsToWorkspace` already archives, so findings survive the job.
- Verified with a local fish fixture harness driving a fake grype: each defect reproduces on the parent commit and passes here, and a seeded finding still blocks, so the tests are not vacuous.
- Worth confirming before this merges: `RELEASE_TYPE=stable` has to reach the four release jobs. None of them set it, the in-repo default is `preview`, and inside those jobs the variable currently only selects the local build tag, so nothing in the repo proves it is set there. If it is not, this is a no-op and the gate needs a different trigger; a job that pins any of the three CVE variables to `0` also still wins.
- Expected consequence once this is live: a stable image with existing high or critical findings blocks on its next publish. That is the intent, but it should not be a surprise mid release cut.
