### PR TITLE
Default CVE gate to run-and-block for stable docker releases (3.12.9)

### DIFF
--- a/helper.linux.fish
+++ b/helper.linux.fish
@@ -1174,6 +1174,24 @@ end
 
 function buildDockerRelease
   echo "building docker release"
+
+  # GA (stable) images must not publish with unreviewed CVEs. Default the
+  # grype gate in validateDockerImageIfNeeded to run-and-block for stable
+  # releases when the operator hasn't already set these explicitly (e.g. via
+  # Jenkins job env), so the check is no longer opt-in for GA publishing.
+  # This only fills in unset values -- any explicit setting (on or off) is
+  # left untouched.
+  if test "$RELEASE_TYPE" = "stable"
+    test -z "$RUN_CVE_CHECKS_FOR_DOCKER_IMAGE"
+    and enableDockerCveCheck
+
+    test -z "$PUBLISH_DOCKER_IMAGE_ONLY_IF_CVE_CHECKS_PASS"
+    and set -xg PUBLISH_DOCKER_IMAGE_ONLY_IF_CVE_CHECKS_PASS 1
+
+    test -z "$CREATE_CVE_REPORT_FOR_DOCKER_IMAGE"
+    and enableCveReport
+  end
+
   sanOff
   and maintainerOff
   and releaseMode


### PR DESCRIPTION
Cherry-pick of bcc3689 from #662 onto `release/arangodb-3.12.9`, so 3.12.9 GA docker builds get the gate. #662 stays open for master.

None of the jenkins release entrypoints set `RUN_CVE_CHECKS_FOR_DOCKER_IMAGE`, `PUBLISH_DOCKER_IMAGE_ONLY_IF_CVE_CHECKS_PASS`, or `CREATE_CVE_REPORT_FOR_DOCKER_IMAGE`, so stable GA images currently publish without a CVE check. This defaults all three on when `RELEASE_TYPE` is stable. Explicit env settings still override, and preview/nightly builds are unaffected.

Worth a dry run against the 3.12.9.4 image before the next release cut: if the current image fails the grype check, the next stable publish blocks, which is the intent, but it should not surprise the release owner.
